### PR TITLE
refactor!: replace sector and field tuple IDs with data structures of 'SectorID' and 'FieldCell'

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,11 @@ Using some example components to track and label an Actor:
 struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
-    source_sector: Option<(u32, u32)>,
-    source_grid_cell: Option<(usize, usize)>,
-    target_sector: Option<(u32, u32)>,
-    target_goal: Option<(usize, usize)>,
-    portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+    source_sector: Option<SectorID>,
+    source_grid_cell: Option<FieldCell>,
+    target_sector: Option<SectorID>,
+    target_goal: Option<FieldCell>,
+    portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ For larger and larger environemnts with an increasing number of pathing actors i
 * FlowField - a 2D array built from the `IntegrationField` which decribes how an actor should move (flow) across the world
 * FlowField Cache - a means of storing `FlowFields` allowing multiple actors to use and reuse them
 * Ordinal - a direction based on traditional compass ordinals: N, NE, E, SE, S, SW, W, NW. Used for discovery of Sectors/field cells at various points within the algorithm
-* Grid cell - an element of a 2D array
-* Goal - the target grid cell an actor needs to path to
+* Field cell - an element of a 2D array
+* Goal - the target field cell an actor needs to path to
 * Portal goal - a target point within a sector that allows an actor to transition to another sector, thus bringing it closer towards/to the goal
 
 # Design/Process
@@ -67,7 +67,7 @@ For a 3-dimensional world the `x-z` (`x-y` in 2d) plane defines the number of Se
 
 <img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/sectors.png" alt="sectors" width="250"/>
 
-Likewise for a `300x550` world you'll be looking at `30` columns and `55` rows. The advantage of dividing a world into Sectors (as opposed to treating the whole world as a giant `Flowfield`) is that the work in generating a path can be split into multiple operations and only touch certain sectors. Say for the `300x550` world you do treat it as a single set of fields - when calculating a path you could potentially have to calculate the Flowfield values for `165,000` grid cells. Splitting it into sectors may mean that your path only takes you through 20 sectors, thereby only requiring `2,000` `Flowfield` grid cells to be calculated.
+Likewise for a `300x550` world you'll be looking at `30` columns and `55` rows. The advantage of dividing a world into Sectors (as opposed to treating the whole world as a giant `Flowfield`) is that the work in generating a path can be split into multiple operations and only touch certain sectors. Say for the `300x550` world you do treat it as a single set of fields - when calculating a path you could potentially have to calculate the Flowfield values for `165,000` field cells. Splitting it into sectors may mean that your path only takes you through 20 sectors, thereby only requiring `2,000` `Flowfield` field cells to be calculated.
 
 </details>
 
@@ -76,7 +76,7 @@ Likewise for a `300x550` world you'll be looking at `30` columns and `55` rows. 
 <details>
 <summary>Click to expand!</summary>
 
-A `CostField` is an `MxN` 2D array of 8-bit values. The values indicate the `cost` of navigating through that cell of the grid. A value of `1` is the default and indicates the easiest `cost`, and a value of `255` is a special value used to indicate that the grid cell is impassable - this could be used to indicate a wall or obstacle. All other values from `2-254` represent increasing cost, for instance a slope or difficult terrain such as a marsh. The idea is that the pathfinding calculations will favour cells with a smaller value before any others.
+A `CostField` is an `MxN` 2D array of 8-bit values. The values indicate the `cost` of navigating through that cell of the field. A value of `1` is the default and indicates the easiest `cost`, and a value of `255` is a special value used to indicate that the field cell is impassable - this could be used to indicate a wall or obstacle. All other values from `2-254` represent increasing cost, for instance a slope or difficult terrain such as a marsh. The idea is that the pathfinding calculations will favour cells with a smaller value before any others.
 
 <img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/cost_field.png" alt="cf" width="370"/>
 
@@ -111,7 +111,7 @@ For finding a path from one Sector to another at a Portal level all Sector Porta
 2. For each sector create `edges` (pathable routes) to and from each Portal `node` - effectively create internal walkable routes of each sector
 3. Create `edges` across the Portal `node` on all sector boundaries (walkable route from one sector to another)
 
-This allows the graph to be queried with a `source` sector and a `target` sector and a list of Portals are returned which can be pathed. When a `CostField` is changed this triggers the regeneration of the sector Portals for the region that `CostField` resides in (and its neighbours to ensure homogenous boundaries) and the graph is updated with any new Portals `nodes` and the old ones are removed. This is a particularly difficult and complicated area as the Sectors, Portals and fields are represented in 2D arrays but the graph is effectively 1D - it's a big long list of `nodes`. To handle identifying a graph `node` from a Sector and field grid cell a special data field exists in `PortalGraph` nicknamed the "translator". It's a way of being able to convert between the graph data structure and the 2D data structure back and forth, so from a grid cell you can find its `node` and from a list of `nodes` (like an A* result) you can find the location of each Portal in the grids.
+This allows the graph to be queried with a `source` sector and a `target` sector and a list of Portals are returned which can be pathed. When a `CostField` is changed this triggers the regeneration of the sector Portals for the region that `CostField` resides in (and its neighbours to ensure homogenous boundaries) and the graph is updated with any new Portals `nodes` and the old ones are removed. This is a particularly difficult and complicated area as the Sectors, Portals and fields are represented in 2D arrays but the graph is effectively 1D - it's a big long list of `nodes`. To handle identifying a graph `node` from a Sector and field field cell a special data field exists in `PortalGraph` nicknamed the "translator". It's a way of being able to convert between the graph data structure and the 2D data structure back and forth, so from a field cell you can find its `node` and from a list of `nodes` (like an A* result) you can find the location of each Portal in the fields.
 
 </details>
 
@@ -122,12 +122,12 @@ This allows the graph to be queried with a `source` sector and a `target` sector
 
 An `IntegrationField` is an `MxN` 2D array of 16-bit values. It uses the `CostField` to produce a cumulative cost to reach the end goal/target. It's an ephemeral field, as in it gets built for a required sector and then consumed by the `FlowField` calculation.
 
-When a new route needs to be processed the field values are set to `u16::MAX` and the grid cell containing the goal is set to `0`.
+When a new route needs to be processed the field values are set to `u16::MAX` and the field cell containing the goal is set to `0`.
 
 A series of passes are performed from the goal as an expanding wavefront calculating the field values:
 
 1. The valid ordinal neighbours of the goal are determined (North, East, South, West - when not against a sector/world boundary)
-2. For each ordinal grid cell lookup their `CostField` value
+2. For each ordinal field cell lookup their `CostField` value
 3. Add the `CostField` cost to the `IntegrationFields` cost of the current cell (at the beginning this is the goal int cost `0`)
 4. Propagate to the next neighbours, find their ordinals and repeat adding their cost value to to the current cells integration cost to produce their cumulative integration cost, and repeat until the entire field is done
 
@@ -136,7 +136,7 @@ This produces a nice diamond-like pattern as the wave expands (the underlying `C
 <img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_prop0.png" alt="ifp0" width="300" height="310"/><img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_prop1.png" alt="ifp1" width="300" height="310"/>
 <img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_prop2.png" alt="ifp2" width="300" height="310"/><img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_prop3.png" alt="ifp3" width="300" height="310"/>
 
-Now a dimaond-like wave isn't exactly realistic in a world of dynamic movement so at some point it should be replaced, based on various articles out there it seems people adopt the [Eikonal equation](https://en.wikipedia.org/wiki/Eikonal_equation) to create a more spherical wave expanding over the grid space.
+Now a dimaond-like wave isn't exactly realistic in a world of dynamic movement so at some point it should be replaced, based on various articles out there it seems people adopt the [Eikonal equation](https://en.wikipedia.org/wiki/Eikonal_equation) to create a more spherical wave expanding over the field space.
 
 When it comes to `CostField` containing impassable markers, `255` as black boxes, they are ignored so the wave flows around those areas:
 
@@ -154,7 +154,7 @@ From the `PortalGraph` we can get a path of `Portals` to guide the actor over se
 
 <img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_sector_to_sector_0.png" alt="ifsts0" width="260" height="310"/><img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_sector_to_sector_1.png" alt="ifsts1" width="260" height="310"/><img src="https://raw.githubusercontent.com/BlondeBurrito/bevy_flowfield_tiles_plugin/main/docs/png/int_field_sector_to_sector_2.png" alt="ifsts2" width="260" height="310"/>
 
-In terms of pathfinding the actor will favour flowing "downhill". From the position of the actor and looking at its grid cell neighbours a smalller value in that sectors `IntegrationField` means a more favourable point for reaching the end goal, going from smaller to smaller values, basically a gradient flowing downhill to the destination.
+In terms of pathfinding the actor will favour flowing "downhill". From the position of the actor and looking at its field cell neighbours a smalller value in that sectors `IntegrationField` means a more favourable point for reaching the end goal, going from smaller to smaller values, basically a gradient flowing downhill to the destination.
 
 This informs the basis of a `FlowField`.
 
@@ -201,7 +201,7 @@ The assistant flags are defined as:
 * `0b0100_0000` - indicates the goal
 * `0b1000_0000` - indicates a portal goal leading to the next sector
 
-So a grid cell in the `FlowField` with a value of `0b0001_0110` means the actor should flow in the South-East direction. In terms of use don't worry about understanding these bit values too much, the [Usage](#usage) section shows the helpers for interpreting the values of the `FlowField` to steer an actor.
+So a field cell in the `FlowField` with a value of `0b0001_0110` means the actor should flow in the South-East direction. In terms of use don't worry about understanding these bit values too much, the [Usage](#usage) section shows the helpers for interpreting the values of the `FlowField` to steer an actor.
 
 Using the `IntegrationFields` generated before, with an actor in the top right trying to reach the bottom left, we now generate the `FlowFields`:
 
@@ -274,7 +274,7 @@ In 2d the dimensions can be configured in different ways:
     cmds.spawn(FlowfieldTilesBundle::new(map_length, map_depth));
 ```
 
-Next you need to seed your `CostFields` to reflect the make up of your world, this can be done programmatically (in 3d you might fire a series of raycasts and based on collider collisions flip a `CostField` grid cell to a higher number via `EventUpdateCostfieldsCell`) or you can load predetermined values from disk.
+Next you need to seed your `CostFields` to reflect the make up of your world, this can be done programmatically (in 3d you might fire a series of raycasts and based on collider collisions flip a `CostField` field cell to a higher number via `EventUpdateCostfieldsCell`) or you can load predetermined values from disk.
 
 ## Path Request
 
@@ -286,7 +286,7 @@ struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
     source_sector: Option<SectorID>,
-    source_grid_cell: Option<FieldCell>,
+    source_field_cell: Option<FieldCell>,
     target_sector: Option<SectorID>,
     target_goal: Option<FieldCell>,
     portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -310,7 +310,7 @@ fn some_system(mut event: EventWriter<EventPathRequest>, ***some other params***
         )
     {
         // actor position in the world
-        if let Some((source_sector_id, source_grid_cell)) = get_sector_and_field_id_from_xy(
+        if let Some((source_sector_id, source_field_cell)) = get_sector_and_field_id_from_xy(
                 tform.translation.truncate(),
                 PIXEL_LENGTH,
                 PIXEL_DEPTH,
@@ -319,7 +319,7 @@ fn some_system(mut event: EventWriter<EventPathRequest>, ***some other params***
             // ask for route generation going from source to target
             event.send(EventPathRequest::new(
                 source_sector_id,
-                source_grid_cell,
+                source_field_cell,
                 target_sector_id,
                 goal_id,
             ));
@@ -367,8 +367,8 @@ fn actor_steering(
     if pathing.target_goal.is_some() {
         // lookup the overarching route
         if let Some(route) = &pathing.portal_route {
-            // find the current actors postion in grid space
-            let (curr_actor_sector, curr_actor_grid) = get_sector_and_field_id_from_xy(
+            // find the current actors postion in field space
+            let (curr_actor_sector, curr_actor_field_cell) = get_sector_and_field_id_from_xy(
                 tform.translation.truncate(),
                 PIXEL_LENGTH,
                 PIXEL_DEPTH,
@@ -380,8 +380,8 @@ fn actor_steering(
                 if *sector == curr_actor_sector {
                     // get the flow field
                     if let Some(field) = flow_cache.get_field(*sector, *goal) {
-                        // based on actor grid cell find the directional vector it should move in
-                        let cell_value = field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+                        // based on actor field cell find the directional vector it should move in
+                        let cell_value = field.get_field_value(curr_actor_field_cell.0, curr_actor_field_cell.1);
                         let dir = get_2d_direction_unit_vector_from_bits(cell_value);
                         let velocity = dir * ACTOR_SPEED;
                         // move the actor based on the velocity

--- a/assets/sector_cost_field_single.ron
+++ b/assets/sector_cost_field_single.ron
@@ -1,6 +1,6 @@
 SectorCostFields(
 	{
-		(0, 0): CostField(
+		SectorID((0, 0)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 255, 255, 255, 1, 1), // column 1

--- a/assets/sector_cost_fields.ron
+++ b/assets/sector_cost_fields.ron
@@ -1,6 +1,6 @@
 SectorCostFields(
 	{
-		(0, 0): CostField(
+		SectorID((0, 0)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 255, 255, 255, 255), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 255, 255, 255), // column 1
@@ -14,7 +14,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(1, 0): CostField(
+		SectorID((1, 0)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 255, 255), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 255, 255), // column 1
@@ -28,7 +28,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(2, 0): CostField(
+		SectorID((2, 0)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -42,7 +42,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 255, 255, 255, 255)  // column 9
 			)
 		),
-		(0, 1): CostField(
+		SectorID((0, 1)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -56,7 +56,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(1, 1): CostField(
+		SectorID((1, 1)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -70,7 +70,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(2, 1): CostField(
+		SectorID((2, 1)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -84,7 +84,7 @@ SectorCostFields(
 				(255, 255, 1, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(0, 2): CostField(
+		SectorID((0, 2)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -98,7 +98,7 @@ SectorCostFields(
 				(1, 1, 1, 1, 1, 1, 1, 255, 255, 255)  // column 9
 			)
 		),
-		(1, 2): CostField(
+		SectorID((1, 2)): CostField(
 			(	// row 0..9
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1
@@ -112,7 +112,7 @@ SectorCostFields(
 				(255, 255, 255, 1, 1, 1, 1, 1, 1, 1)  // column 9
 			)
 		),
-		(2, 2): CostField(
+		SectorID((2, 2)): CostField(
 			(	// row 0..9
 				(255, 255, 1, 1, 1, 1, 1, 1, 1, 1), // column 0
 				(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), // column 1

--- a/benches/calc_flow_maze.rs
+++ b/benches/calc_flow_maze.rs
@@ -99,7 +99,7 @@ fn flow_maze(
 				sectors_expanded_goals.push((*sector_id, vec![*goal]));
 			} else {
 				// portals represent the boundary to another sector, a portal can be spread over
-				// multple grid cells, expand the portal to provide multiple goal
+				// multple field cells, expand the portal to provide multiple goal
 				// targets for moving to another sector
 				let neighbour_sector_id = path[i - 1].0;
 				let g = portals

--- a/benches/calc_flow_maze.rs
+++ b/benches/calc_flow_maze.rs
@@ -50,12 +50,12 @@ fn prepare_fields(
 
 	let mut route_cache = RouteCache::default();
 	// bottom left
-	let source_sector = (0, 99);
-	let source_field_cell = (0, 9);
+	let source_sector = SectorID::new(0, 99);
+	let source_field_cell = FieldCell::new(0, 9);
 	let source = (source_sector, source_field_cell);
 	// bottom right
-	let target_sector = (99, 99);
-	let target_goal = (9, 9);
+	let target_sector = SectorID::new(99, 99);
+	let target_goal = FieldCell::new(9, 9);
 	let target = (target_sector, target_goal);
 
 	// find the route

--- a/benches/calc_flow_open.rs
+++ b/benches/calc_flow_open.rs
@@ -118,7 +118,7 @@ fn flow_open(
 				sectors_expanded_goals.push((*sector_id, vec![*goal]));
 			} else {
 				// portals represent the boundary to another sector, a portal can be spread over
-				// multple grid cells, expand the portal to provide multiple goal
+				// multple field cells, expand the portal to provide multiple goal
 				// targets for moving to another sector
 				let neighbour_sector_id = path[i - 1].0;
 				let g = portals

--- a/benches/calc_flow_open.rs
+++ b/benches/calc_flow_open.rs
@@ -70,12 +70,12 @@ fn prepare_fields(
 
 	let mut route_cache = RouteCache::default();
 	// top right
-	let source_sector = (99, 0);
-	let source_field_cell = (9, 0);
+	let source_sector = SectorID::new(99, 0);
+	let source_field_cell = FieldCell::new(9, 0);
 	let source = (source_sector, source_field_cell);
 	// bottom left
-	let target_sector = (0, 99);
-	let target_goal = (0, 9);
+	let target_sector = SectorID::new(0, 99);
+	let target_goal = FieldCell::new(0, 9);
 	let target = (target_sector, target_goal);
 
 	// find the route

--- a/benches/calc_flow_sparse.rs
+++ b/benches/calc_flow_sparse.rs
@@ -36,12 +36,12 @@ fn prepare_fields(
 
 	let mut route_cache = RouteCache::default();
 	// top right
-	let source_sector = (99, 0);
-	let source_field_cell = (9, 0);
+	let source_sector = SectorID::new(99, 0);
+	let source_field_cell = FieldCell::new(9, 0);
 	let source = (source_sector, source_field_cell);
 	// bottom left
-	let target_sector = (0, 99);
-	let target_goal = (0, 9);
+	let target_sector = SectorID::new(0, 99);
+	let target_goal = FieldCell::new(0, 9);
 	let target = (target_sector, target_goal);
 
 	// find the route

--- a/benches/calc_flow_sparse.rs
+++ b/benches/calc_flow_sparse.rs
@@ -84,7 +84,7 @@ fn flow_sparse(
 				sectors_expanded_goals.push((*sector_id, vec![*goal]));
 			} else {
 				// portals represent the boundary to another sector, a portal can be spread over
-				// multple grid cells, expand the portal to provide multiple goal
+				// multple field cells, expand the portal to provide multiple goal
 				// targets for moving to another sector
 				let neighbour_sector_id = path[i - 1].0;
 				let g = portals

--- a/benches/calc_route.rs
+++ b/benches/calc_route.rs
@@ -40,12 +40,12 @@ fn calc(portals: SectorPortals, cost_fields: SectorCostFields, graph: PortalGrap
 	let mut route_cache = RouteCache::default();
 
 	// top right
-	let source_sector = (99, 0);
-	let source_field_cell = (9, 0);
+	let source_sector = SectorID::new(99, 0);
+	let source_field_cell = FieldCell::new(9, 0);
 	let source = (source_sector, source_field_cell);
 	// bottom left
-	let target_sector = (0, 99);
-	let target_goal = (0, 9);
+	let target_sector = SectorID::new(0, 99);
+	let target_goal = FieldCell::new(0, 9);
 	let target = (target_sector, target_goal);
 
 	// find the route

--- a/examples/2d_multi_actor.rs
+++ b/examples/2d_multi_actor.rs
@@ -41,11 +41,11 @@ struct Actor;
 #[allow(clippy::missing_docs_in_private_items)]
 #[derive(Default, Component)]
 struct Pathing {
-	source_sector: Option<(u32, u32)>,
-	source_grid_cell: Option<(usize, usize)>,
-	target_sector: Option<(u32, u32)>,
-	target_goal: Option<(usize, usize)>,
-	portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+	source_sector: Option<SectorID>,
+	source_grid_cell: Option<FieldCell>,
+	target_sector: Option<SectorID>,
+	target_goal: Option<FieldCell>,
+	portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 
 /// Spawn sprites to represent the world
@@ -80,7 +80,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					..default()
 				})
 				.insert(GridLabel(i, j))
-				.insert(SectorLabel(sector_id.0, sector_id.1));
+				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
 	}
@@ -231,7 +231,7 @@ fn actor_steering(
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
 							// based on actor grid cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+								field.get_grid_value(curr_actor_grid);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
 							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
 							// info!("Direction to move: {}", dir);

--- a/examples/2d_multi_actor.rs
+++ b/examples/2d_multi_actor.rs
@@ -30,7 +30,7 @@ struct SectorLabel(u32, u32);
 
 /// Helper component attached to each sprite, allows for the visualisation to be updated, you wouldn't use this in a real simulation
 #[derive(Component)]
-struct GridLabel(usize, usize);
+struct FieldCellLabel(usize, usize);
 
 /// Labels the actor to enable getting its [Transform] easily
 #[derive(Component)]
@@ -42,7 +42,7 @@ struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
 	source_sector: Option<SectorID>,
-	source_grid_cell: Option<FieldCell>,
+	source_field_cell: Option<FieldCell>,
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -79,7 +79,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					transform: Transform::from_xyz(x, y, 0.0),
 					..default()
 				})
-				.insert(GridLabel(i, j))
+				.insert(FieldCellLabel(i, j))
 				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
@@ -149,7 +149,7 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				for (tform, mut pathing) in actor_q.iter_mut() {
-					let (source_sector_id, source_grid_cell) = get_sector_and_field_id_from_xy(
+					let (source_sector_id, source_field_cell) = get_sector_and_field_id_from_xy(
 						tform.translation.truncate(),
 						PIXEL_LENGTH,
 						PIXEL_DEPTH,
@@ -158,17 +158,17 @@ fn user_input(
 					.unwrap();
 					info!(
 						"Actor sector_id {:?}, goal_id in sector {:?}",
-						source_sector_id, source_grid_cell
+						source_sector_id, source_field_cell
 					);
 					event.send(EventPathRequest::new(
 						source_sector_id,
-						source_grid_cell,
+						source_field_cell,
 						target_sector_id,
 						goal_id,
 					));
 					// update the actor pathing
 					pathing.source_sector = Some(source_sector_id);
-					pathing.source_grid_cell = Some(source_grid_cell);
+					pathing.source_field_cell = Some(source_field_cell);
 					pathing.target_sector = Some(target_sector_id);
 					pathing.target_goal = Some(goal_id);
 					pathing.portal_route = None;
@@ -210,7 +210,7 @@ fn actor_steering(
 			if let Some(route) = pathing.portal_route.as_mut() {
 				// info!("Route: {:?}", route);
 				// find the current actors postion in grid space
-				let (curr_actor_sector, curr_actor_grid) = get_sector_and_field_id_from_xy(
+				let (curr_actor_sector, curr_actor_field_cell) = get_sector_and_field_id_from_xy(
 					tform.translation.truncate(),
 					PIXEL_LENGTH,
 					PIXEL_DEPTH,
@@ -229,11 +229,11 @@ fn actor_steering(
 					if *sector == curr_actor_sector {
 						// get the flow field
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
-							// based on actor grid cell find the directional vector it should move in
+							// based on actor field cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid);
+								field.get_field_cell_value(curr_actor_field_cell);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
+							// info!("In sector {:?}, in field cell {:?}", sector, curr_actor_field_cell);
 							// info!("Direction to move: {}", dir);
 							let velocity = dir * SPEED;
 							// move the actor based on the velocity

--- a/examples/2d_multi_actor_controls.rs
+++ b/examples/2d_multi_actor_controls.rs
@@ -44,11 +44,11 @@ struct ActorB;
 #[allow(clippy::missing_docs_in_private_items)]
 #[derive(Default, Component)]
 struct Pathing {
-	source_sector: Option<(u32, u32)>,
-	source_grid_cell: Option<(usize, usize)>,
-	target_sector: Option<(u32, u32)>,
-	target_goal: Option<(usize, usize)>,
-	portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+	source_sector: Option<SectorID>,
+	source_grid_cell: Option<FieldCell>,
+	target_sector: Option<SectorID>,
+	target_goal: Option<FieldCell>,
+	portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 
 /// Spawn sprites to represent the world
@@ -83,7 +83,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					..default()
 				})
 				.insert(GridLabel(i, j))
-				.insert(SectorLabel(sector_id.0, sector_id.1));
+				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
 	}
@@ -296,7 +296,7 @@ fn actor_steering(
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
 							// based on actor grid cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+								field.get_grid_value(curr_actor_grid);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
 							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
 							// info!("Direction to move: {}", dir);
@@ -337,7 +337,7 @@ fn actor_steering(
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
 							// based on actor grid cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+								field.get_grid_value(curr_actor_grid);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
 							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
 							// info!("Direction to move: {}", dir);

--- a/examples/2d_multi_actor_controls.rs
+++ b/examples/2d_multi_actor_controls.rs
@@ -30,7 +30,7 @@ struct SectorLabel(u32, u32);
 
 /// Helper component attached to each sprite, allows for the visualisation to be updated, you wouldn't use this in a real simulation
 #[derive(Component)]
-struct GridLabel(usize, usize);
+struct FieldCellLabel(usize, usize);
 
 /// Labels the Actor to enable getting its [Transform] easily
 #[derive(Component)]
@@ -45,7 +45,7 @@ struct ActorB;
 #[derive(Default, Component)]
 struct Pathing {
 	source_sector: Option<SectorID>,
-	source_grid_cell: Option<FieldCell>,
+	source_field_cell: Option<FieldCell>,
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -82,7 +82,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					transform: Transform::from_xyz(x, y, 0.0),
 					..default()
 				})
-				.insert(GridLabel(i, j))
+				.insert(FieldCellLabel(i, j))
 				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
@@ -146,7 +146,7 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				for (tform, mut pathing) in actor_a_q.iter_mut() {
-					let (source_sector_id, source_grid_cell) = get_sector_and_field_id_from_xy(
+					let (source_sector_id, source_field_cell) = get_sector_and_field_id_from_xy(
 						tform.translation.truncate(),
 						PIXEL_LENGTH,
 						PIXEL_DEPTH,
@@ -155,17 +155,17 @@ fn user_input(
 					.unwrap();
 					info!(
 						"Actor sector_id {:?}, goal_id in sector {:?}",
-						source_sector_id, source_grid_cell
+						source_sector_id, source_field_cell
 					);
 					event.send(EventPathRequest::new(
 						source_sector_id,
-						source_grid_cell,
+						source_field_cell,
 						target_sector_id,
 						goal_id,
 					));
 					// update the Actor pathing
 					pathing.source_sector = Some(source_sector_id);
-					pathing.source_grid_cell = Some(source_grid_cell);
+					pathing.source_field_cell = Some(source_field_cell);
 					pathing.target_sector = Some(target_sector_id);
 					pathing.target_goal = Some(goal_id);
 					pathing.portal_route = None;
@@ -196,7 +196,7 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				for (tform, mut pathing) in actor_b_q.iter_mut() {
-					let (source_sector_id, source_grid_cell) = get_sector_and_field_id_from_xy(
+					let (source_sector_id, source_field_cell) = get_sector_and_field_id_from_xy(
 						tform.translation.truncate(),
 						PIXEL_LENGTH,
 						PIXEL_DEPTH,
@@ -205,17 +205,17 @@ fn user_input(
 					.unwrap();
 					info!(
 						"Actor sector_id {:?}, goal_id in sector {:?}",
-						source_sector_id, source_grid_cell
+						source_sector_id, source_field_cell
 					);
 					event.send(EventPathRequest::new(
 						source_sector_id,
-						source_grid_cell,
+						source_field_cell,
 						target_sector_id,
 						goal_id,
 					));
 					// update the Actor pathing
 					pathing.source_sector = Some(source_sector_id);
-					pathing.source_grid_cell = Some(source_grid_cell);
+					pathing.source_field_cell = Some(source_field_cell);
 					pathing.target_sector = Some(target_sector_id);
 					pathing.target_goal = Some(goal_id);
 					pathing.portal_route = None;
@@ -275,7 +275,7 @@ fn actor_steering(
 			if let Some(route) = pathing.portal_route.as_mut() {
 				// info!("Route: {:?}", route);
 				// find the current actors postion in grid space
-				let (curr_actor_sector, curr_actor_grid) = get_sector_and_field_id_from_xy(
+				let (curr_actor_sector, curr_actor_field_cell) = get_sector_and_field_id_from_xy(
 					tform.translation.truncate(),
 					PIXEL_LENGTH,
 					PIXEL_DEPTH,
@@ -294,11 +294,11 @@ fn actor_steering(
 					if *sector == curr_actor_sector {
 						// get the flow field
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
-							// based on actor grid cell find the directional vector it should move in
+							// based on actor field cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid);
+								field.get_field_cell_value(curr_actor_field_cell);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
+							// info!("In sector {:?}, in field cell {:?}", sector, curr_actor_field_cell);
 							// info!("Direction to move: {}", dir);
 							let velocity = dir * SPEED;
 							// move the actor based on the velocity
@@ -316,7 +316,7 @@ fn actor_steering(
 			if let Some(route) = pathing.portal_route.as_mut() {
 				// info!("Route: {:?}", route);
 				// find the current actors postion in grid space
-				let (curr_actor_sector, curr_actor_grid) = get_sector_and_field_id_from_xy(
+				let (curr_actor_sector, curr_actor_field_cell) = get_sector_and_field_id_from_xy(
 					tform.translation.truncate(),
 					PIXEL_LENGTH,
 					PIXEL_DEPTH,
@@ -335,11 +335,11 @@ fn actor_steering(
 					if *sector == curr_actor_sector {
 						// get the flow field
 						if let Some(field) = flow_cache.get_field(*sector, *goal) {
-							// based on actor grid cell find the directional vector it should move in
+							// based on actor field cell find the directional vector it should move in
 							let cell_value =
-								field.get_grid_value(curr_actor_grid);
+								field.get_field_cell_value(curr_actor_field_cell);
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-							// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
+							// info!("In sector {:?}, in field cell {:?}", sector, curr_actor_field_cell);
 							// info!("Direction to move: {}", dir);
 							let velocity = dir * SPEED;
 							// move the actor based on the velocity

--- a/examples/2d_with_steering.rs
+++ b/examples/2d_with_steering.rs
@@ -33,7 +33,7 @@ struct SectorLabel(u32, u32);
 
 /// Helper component attached to each sprite, allows for the visualisation to be updated, you wouldn't use this in a real simulation
 #[derive(Component)]
-struct GridLabel(usize, usize);
+struct FieldCellLabel(usize, usize);
 
 /// Labels the actor to enable getting its [Transform] easily
 #[derive(Component)]
@@ -45,7 +45,7 @@ struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
 	source_sector: Option<SectorID>,
-	source_grid_cell: Option<FieldCell>,
+	source_field_cell: Option<FieldCell>,
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -82,7 +82,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					transform: Transform::from_xyz(x, y, 0.0),
 					..default()
 				})
-				.insert(GridLabel(i, j))
+				.insert(FieldCellLabel(i, j))
 				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
@@ -136,7 +136,7 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				let (tform, mut pathing) = actor_q.get_single_mut().unwrap();
-				let (source_sector_id, source_grid_cell) = get_sector_and_field_id_from_xy(
+				let (source_sector_id, source_field_cell) = get_sector_and_field_id_from_xy(
 					tform.translation.truncate(),
 					PIXEL_LENGTH,
 					PIXEL_DEPTH,
@@ -145,17 +145,17 @@ fn user_input(
 				.unwrap();
 				info!(
 					"Actor sector_id {:?}, goal_id in sector {:?}",
-					source_sector_id, source_grid_cell
+					source_sector_id, source_field_cell
 				);
 				event.send(EventPathRequest::new(
 					source_sector_id,
-					source_grid_cell,
+					source_field_cell,
 					target_sector_id,
 					goal_id,
 				));
 				// update the actor pathing
 				pathing.source_sector = Some(source_sector_id);
-				pathing.source_grid_cell = Some(source_grid_cell);
+				pathing.source_field_cell = Some(source_field_cell);
 				pathing.target_sector = Some(target_sector_id);
 				pathing.target_goal = Some(goal_id);
 				pathing.portal_route = None;
@@ -196,7 +196,7 @@ fn actor_steering(
 		if let Some(route) = pathing.portal_route.as_mut() {
 			// info!("Route: {:?}", route);
 			// find the current actors postion in grid space
-			let (curr_actor_sector, curr_actor_grid) = get_sector_and_field_id_from_xy(
+			let (curr_actor_sector, curr_actor_field_cell) = get_sector_and_field_id_from_xy(
 				tform.translation.truncate(),
 				PIXEL_LENGTH,
 				PIXEL_DEPTH,
@@ -215,10 +215,10 @@ fn actor_steering(
 				if *sector == curr_actor_sector {
 					// get the flow field
 					if let Some(field) = flow_cache.get_field(*sector, *goal) {
-						// based on actor grid cell find the directional vector it should move in
-						let cell_value = field.get_grid_value(curr_actor_grid);
+						// based on actor field cell find the directional vector it should move in
+						let cell_value = field.get_field_cell_value(curr_actor_field_cell);
 						let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-						// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
+						// info!("In sector {:?}, in field cell {:?}", sector, curr_actor_field_cell);
 						// info!("Direction to move: {}", dir);
 						let velocity = dir * SPEED;
 						// move the actor based on the velocity
@@ -246,7 +246,7 @@ fn update_sprite_visuals_based_on_actor(
 	actor_q: Query<&Pathing, With<Actor>>,
 	flowfield_q: Query<&FlowFieldCache>,
 	costfield_q: Query<&SectorCostFields>,
-	mut grid_q: Query<(&mut Handle<Image>, &GridLabel, &SectorLabel)>,
+	mut field_cell_q: Query<(&mut Handle<Image>, &FieldCellLabel, &SectorLabel)>,
 	asset_server: Res<AssetServer>,
 ) {
 	let f_cache = flowfield_q.get_single().unwrap();
@@ -257,7 +257,7 @@ fn update_sprite_visuals_based_on_actor(
 		for (s, g) in route.iter() {
 			route_map.insert(*s, *g);
 		}
-		for (mut handle, grid_label, sector_label) in grid_q.iter_mut() {
+		for (mut handle, field_cell_label, sector_label) in field_cell_q.iter_mut() {
 			// look for the value in the route_map if it's part of the flow, otherwise use the cost field
 			if route_map.contains_key(&SectorID::new(sector_label.0, sector_label.1)) {
 				let goal = route_map
@@ -266,7 +266,7 @@ fn update_sprite_visuals_based_on_actor(
 				if let Some(flowfield) =
 					f_cache.get_field(SectorID::new(sector_label.0, sector_label.1), *goal)
 				{
-					let flow_value = flowfield.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
+					let flow_value = flowfield.get_field_cell_value(FieldCell::new(field_cell_label.0, field_cell_label.1));
 					let icon = get_ord_icon(flow_value);
 					let new_handle: Handle<Image> = asset_server.load(icon);
 					*handle = new_handle;
@@ -276,7 +276,7 @@ fn update_sprite_visuals_based_on_actor(
 					.get()
 					.get(&SectorID::new(sector_label.0, sector_label.1))
 					.unwrap()
-					.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
+					.get_field_cell_value(FieldCell::new(field_cell_label.0, field_cell_label.1));
 				let icon = get_basic_icon(value);
 				let new_handle: Handle<Image> = asset_server.load(icon);
 				*handle = new_handle;

--- a/examples/2d_with_steering.rs
+++ b/examples/2d_with_steering.rs
@@ -44,11 +44,11 @@ struct Actor;
 #[allow(clippy::missing_docs_in_private_items)]
 #[derive(Default, Component)]
 struct Pathing {
-	source_sector: Option<(u32, u32)>,
-	source_grid_cell: Option<(usize, usize)>,
-	target_sector: Option<(u32, u32)>,
-	target_goal: Option<(usize, usize)>,
-	portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+	source_sector: Option<SectorID>,
+	source_grid_cell: Option<FieldCell>,
+	target_sector: Option<SectorID>,
+	target_goal: Option<FieldCell>,
+	portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 
 /// Spawn sprites to represent the world
@@ -83,7 +83,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					..default()
 				})
 				.insert(GridLabel(i, j))
-				.insert(SectorLabel(sector_id.0, sector_id.1));
+				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
 	}
@@ -216,7 +216,7 @@ fn actor_steering(
 					// get the flow field
 					if let Some(field) = flow_cache.get_field(*sector, *goal) {
 						// based on actor grid cell find the directional vector it should move in
-						let cell_value = field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+						let cell_value = field.get_grid_value(curr_actor_grid);
 						let dir = get_2d_direction_unit_vector_from_bits(cell_value);
 						// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
 						// info!("Direction to move: {}", dir);
@@ -253,17 +253,20 @@ fn update_sprite_visuals_based_on_actor(
 	let sc_cache = costfield_q.get_single().unwrap();
 	let pathing = actor_q.get_single().unwrap();
 	if let Some(route) = &pathing.portal_route {
-		let mut route_map: HashMap<(u32, u32), (usize, usize)> = HashMap::new();
+		let mut route_map: HashMap<SectorID, FieldCell> = HashMap::new();
 		for (s, g) in route.iter() {
 			route_map.insert(*s, *g);
 		}
 		for (mut handle, grid_label, sector_label) in grid_q.iter_mut() {
 			// look for the value in the route_map if it's part of the flow, otherwise use the cost field
-			if route_map.contains_key(&(sector_label.0, sector_label.1)) {
-				let goal = route_map.get(&(sector_label.0, sector_label.1)).unwrap();
-				if let Some(flowfield) = f_cache.get_field((sector_label.0, sector_label.1), *goal)
+			if route_map.contains_key(&SectorID::new(sector_label.0, sector_label.1)) {
+				let goal = route_map
+					.get(&SectorID::new(sector_label.0, sector_label.1))
+					.unwrap();
+				if let Some(flowfield) =
+					f_cache.get_field(SectorID::new(sector_label.0, sector_label.1), *goal)
 				{
-					let flow_value = flowfield.get_grid_value(grid_label.0, grid_label.1);
+					let flow_value = flowfield.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
 					let icon = get_ord_icon(flow_value);
 					let new_handle: Handle<Image> = asset_server.load(icon);
 					*handle = new_handle;
@@ -271,9 +274,9 @@ fn update_sprite_visuals_based_on_actor(
 			} else {
 				let value = sc_cache
 					.get()
-					.get(&(sector_label.0, sector_label.1))
+					.get(&SectorID::new(sector_label.0, sector_label.1))
 					.unwrap()
-					.get_grid_value(grid_label.0, grid_label.1);
+					.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
 				let icon = get_basic_icon(value);
 				let new_handle: Handle<Image> = asset_server.load(icon);
 				*handle = new_handle;

--- a/examples/3d_actor_movement.rs
+++ b/examples/3d_actor_movement.rs
@@ -32,7 +32,7 @@ struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
 	source_sector: Option<SectorID>,
-	source_grid_cell: Option<FieldCell>,
+	source_field_cell: Option<FieldCell>,
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -120,22 +120,22 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				let (tform, mut pathing) = actor_q.get_single_mut().unwrap();
-				let (source_sector_id, source_grid_cell) =
+				let (source_sector_id, source_field_cell) =
 					get_sector_and_field_cell_from_xyz(tform.translation, MAP_LENGTH, MAP_DPETH)
 						.unwrap();
 				info!(
 					"Actor sector_id {:?}, goal_id in sector {:?}",
-					source_sector_id, source_grid_cell
+					source_sector_id, source_field_cell
 				);
 				event.send(EventPathRequest::new(
 					source_sector_id,
-					source_grid_cell,
+					source_field_cell,
 					target_sector_id,
 					goal_id,
 				));
 				// update the actor pathing
 				pathing.source_sector = Some(source_sector_id);
-				pathing.source_grid_cell = Some(source_grid_cell);
+				pathing.source_field_cell = Some(source_field_cell);
 				pathing.target_sector = Some(target_sector_id);
 				pathing.target_goal = Some(goal_id);
 				pathing.portal_route = None;
@@ -176,7 +176,7 @@ fn actor_steering(
 		if let Some(route) = pathing.portal_route.as_mut() {
 			// info!("Route: {:?}", route);
 			// find the current actors postion in grid space
-			let (curr_actor_sector, curr_actor_grid) =
+			let (curr_actor_sector, curr_actor_field_cell) =
 				get_sector_and_field_cell_from_xyz(tform.translation, MAP_LENGTH, MAP_DPETH)
 					.unwrap();
 			// tirm the actor stored route as it makes progress
@@ -191,10 +191,10 @@ fn actor_steering(
 				if *sector == curr_actor_sector {
 					// get the flow field
 					if let Some(field) = flow_cache.get_field(*sector, *goal) {
-						// based on actor grid cell find the directional vector it should move in
-						let cell_value = field.get_grid_value(curr_actor_grid);
+						// based on actor field cell find the directional vector it should move in
+						let cell_value = field.get_field_cell_value(curr_actor_field_cell);
 						let dir = get_3d_direction_unit_vector_from_bits(cell_value);
-						// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
+						// info!("In sector {:?}, in field cell {:?}", sector, curr_actor_field_cell);
 						// info!("Direction to move: {}", dir);
 						let velocity = dir * SPEED;
 						// move the actor based on the velocity

--- a/examples/3d_actor_movement.rs
+++ b/examples/3d_actor_movement.rs
@@ -31,11 +31,11 @@ struct Actor;
 #[allow(clippy::missing_docs_in_private_items)]
 #[derive(Default, Component)]
 struct Pathing {
-	source_sector: Option<(u32, u32)>,
-	source_grid_cell: Option<(usize, usize)>,
-	target_sector: Option<(u32, u32)>,
-	target_goal: Option<(usize, usize)>,
-	portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+	source_sector: Option<SectorID>,
+	source_grid_cell: Option<FieldCell>,
+	target_sector: Option<SectorID>,
+	target_goal: Option<FieldCell>,
+	portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 
 /// Spawn the map
@@ -192,7 +192,7 @@ fn actor_steering(
 					// get the flow field
 					if let Some(field) = flow_cache.get_field(*sector, *goal) {
 						// based on actor grid cell find the directional vector it should move in
-						let cell_value = field.get_grid_value(curr_actor_grid.0, curr_actor_grid.1);
+						let cell_value = field.get_grid_value(curr_actor_grid);
 						let dir = get_3d_direction_unit_vector_from_bits(cell_value);
 						// info!("In sector {:?}, in grid cell {:?}", sector, curr_actor_grid);
 						// info!("Direction to move: {}", dir);

--- a/examples/flow_field_right_click.rs
+++ b/examples/flow_field_right_click.rs
@@ -28,7 +28,7 @@ fn main() {
 }
 /// Helper component attached to each sprite, allows for the visualisation to be updated, you wouldn't use this in a real simulation
 #[derive(Component)]
-struct GridLabel(usize, usize);
+struct FieldCellLabel(usize, usize);
 /// Labels the actor to enable getting its [Transform] easily
 #[derive(Component)]
 struct Actor;
@@ -38,7 +38,7 @@ struct Actor;
 #[derive(Default, Component)]
 struct Pathing {
 	source_sector: Option<SectorID>,
-	source_grid_cell: Option<FieldCell>,
+	source_field_cell: Option<FieldCell>,
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
@@ -69,7 +69,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 				transform: Transform::from_xyz(x, y, 0.0),
 				..default()
 			})
-			.insert(GridLabel(i, j));
+			.insert(FieldCellLabel(i, j));
 		}
 	}
 	// create the controllable actor
@@ -110,7 +110,7 @@ fn user_input(
 					target_sector_id, goal_id
 				);
 				let (tform, mut pathing) = actor_q.get_single_mut().unwrap();
-				let (source_sector_id, source_grid_cell) = get_sector_and_field_id_from_xy(
+				let (source_sector_id, source_field_cell) = get_sector_and_field_id_from_xy(
 					tform.translation.truncate(),
 					PIXEL_LENGTH,
 					PIXEL_DEPTH,
@@ -119,17 +119,17 @@ fn user_input(
 				.unwrap();
 				info!(
 					"Actor sector_id {:?}, goal_id in sector {:?}",
-					source_sector_id, source_grid_cell
+					source_sector_id, source_field_cell
 				);
 				event.send(EventPathRequest::new(
 					source_sector_id,
-					source_grid_cell,
+					source_field_cell,
 					target_sector_id,
 					goal_id,
 				));
 				// update the actor pathing
 				pathing.source_sector = Some(source_sector_id);
-				pathing.source_grid_cell = Some(source_grid_cell);
+				pathing.source_field_cell = Some(source_field_cell);
 				pathing.target_sector = Some(target_sector_id);
 				pathing.target_goal = Some(goal_id);
 			} else {
@@ -157,7 +157,7 @@ fn actor_update_route(mut actor_q: Query<&mut Pathing, With<Actor>>, route_q: Qu
 fn update_sprite_visuals_based_on_actor(
 	actor_q: Query<&Pathing, With<Actor>>,
 	flowfield_q: Query<&FlowFieldCache>,
-	mut grid_q: Query<(&mut Handle<Image>, &GridLabel)>,
+	mut field_cell_q: Query<(&mut Handle<Image>, &FieldCellLabel)>,
 	asset_server: Res<AssetServer>,
 ) {
 	let pathing = actor_q.get_single().unwrap();
@@ -165,8 +165,8 @@ fn update_sprite_visuals_based_on_actor(
 	if let Some(route) = &pathing.portal_route {
 		let op_flowfield = cache.get_field(route[0].0, route[0].1);
 		if let Some(flowfield) = op_flowfield {
-			for (mut handle, grid_label) in grid_q.iter_mut() {
-				let flow_value = flowfield.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
+			for (mut handle, field_cell_label) in field_cell_q.iter_mut() {
+				let flow_value = flowfield.get_field_cell_value(FieldCell::new(field_cell_label.0, field_cell_label.1));
 				let icon = get_ord_icon(flow_value);
 				let new_handle: Handle<Image> = asset_server.load(icon);
 				*handle = new_handle;

--- a/examples/flow_field_right_click.rs
+++ b/examples/flow_field_right_click.rs
@@ -37,11 +37,11 @@ struct Actor;
 #[allow(clippy::missing_docs_in_private_items)]
 #[derive(Default, Component)]
 struct Pathing {
-	source_sector: Option<(u32, u32)>,
-	source_grid_cell: Option<(usize, usize)>,
-	target_sector: Option<(u32, u32)>,
-	target_goal: Option<(usize, usize)>,
-	portal_route: Option<Vec<((u32, u32), (usize, usize))>>,
+	source_sector: Option<SectorID>,
+	source_grid_cell: Option<FieldCell>,
+	target_sector: Option<SectorID>,
+	target_goal: Option<FieldCell>,
+	portal_route: Option<Vec<(SectorID, FieldCell)>>,
 }
 /// Init bundle and setup world and actor
 fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
@@ -166,7 +166,7 @@ fn update_sprite_visuals_based_on_actor(
 		let op_flowfield = cache.get_field(route[0].0, route[0].1);
 		if let Some(flowfield) = op_flowfield {
 			for (mut handle, grid_label) in grid_q.iter_mut() {
-				let flow_value = flowfield.get_grid_value(grid_label.0, grid_label.1);
+				let flow_value = flowfield.get_grid_value(FieldCell::new(grid_label.0, grid_label.1));
 				let icon = get_ord_icon(flow_value);
 				let new_handle: Handle<Image> = asset_server.load(icon);
 				*handle = new_handle;

--- a/examples/visualise_flow_field_tiles.rs
+++ b/examples/visualise_flow_field_tiles.rs
@@ -40,25 +40,25 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	);
 	//
 	let source_sector = SectorID::new(2, 0);
-	let source_grid_cell = FieldCell::new(7, 3);
+	let source_field_cell = FieldCell::new(7, 3);
 	let target_sector = SectorID::new(0, 2);
-	let target_grid_cell = FieldCell::new(0, 6);
+	let target_field_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(
-			(source_sector, source_grid_cell),
-			(target_sector, target_grid_cell),
+			(source_sector, source_field_cell),
+			(target_sector, target_field_cell),
 			&sector_portals,
 			&sector_cost_fields,
 		)
 		.unwrap();
-	// convert to grid and sector coords
+	// convert to field cell and sector coords
 	let mut path =
 		portal_graph.convert_index_path_to_sector_portal_cells(node_path.1, &sector_portals);
 	let mut path_based_on_portal_exits = Vec::new();
 	// target sector and entry portal where we switch the entry portal cell to the goal
 	let mut end = path.pop().unwrap();
-	end.1 = target_grid_cell;
+	end.1 = target_field_cell;
 	// sector and field of leaving starting sector if source sector and target sector are different
 	// otherwise it was a single element path and we already removed it
 	if !path.is_empty() {
@@ -80,7 +80,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 			sectors_expanded_goals.push((*sector_id, vec![*goal]));
 		} else {
 			// portals represent the boundary to another sector, a portal can be spread over
-			// multple grid cells, expand the portal to provide multiple goal
+			// multple field cells, expand the portal to provide multiple goal
 			// targets for moving to another sector
 			let neighbour_sector_id = path[i - 1].0;
 			let g = sector_portals

--- a/examples/visualise_flow_field_tiles.rs
+++ b/examples/visualise_flow_field_tiles.rs
@@ -39,10 +39,10 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 		map_dimensions.get_row(),
 	);
 	//
-	let source_sector = (2, 0);
-	let source_grid_cell = (7, 3);
-	let target_sector = (0, 2);
-	let target_grid_cell = (0, 6);
+	let source_sector = SectorID::new(2, 0);
+	let source_grid_cell = FieldCell::new(7, 3);
+	let target_sector = SectorID::new(0, 2);
+	let target_grid_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(
@@ -168,7 +168,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					})
 					.with_children(|p| {
 						// the array area of the sector
-						let flow_field = sector_flow_fields.get(&(i, j));
+						let flow_field = sector_flow_fields.get(&SectorID::new(i, j));
 						if let Some(field) = flow_field {
 							// create each column from the field
 							for array in field.get_field().iter() {

--- a/examples/visualise_integration_field.rs
+++ b/examples/visualise_integration_field.rs
@@ -16,7 +16,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	let path = env!("CARGO_MANIFEST_DIR").to_string() + "/assets/cost_field_impassable.ron";
 	let cost_field = CostField::from_file(path);
 	let mut int_field = IntegrationField::default();
-	let source = vec![(4, 4)];
+	let source = vec![FieldCell::new(4, 4)];
 	int_field.reset(&source);
 	int_field.calculate_field(&source, &cost_field);
 	// create a UI grid

--- a/examples/visualise_integration_fields.rs
+++ b/examples/visualise_integration_fields.rs
@@ -40,25 +40,25 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	);
 	//
 	let source_sector = SectorID::new(2, 0);
-	let source_grid_cell = FieldCell::new(7, 3);
+	let source_field_cell = FieldCell::new(7, 3);
 	let target_sector = SectorID::new(0, 2);
-	let target_grid_cell = FieldCell::new(0, 6);
+	let target_field_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(
-			(source_sector, source_grid_cell),
-			(target_sector, target_grid_cell),
+			(source_sector, source_field_cell),
+			(target_sector, target_field_cell),
 			&sector_portals,
 			&sector_cost_fields,
 		)
 		.unwrap();
-	// convert to grid and sector coords
+	// convert to field cell and sector coords
 	let mut path =
 		portal_graph.convert_index_path_to_sector_portal_cells(node_path.1, &sector_portals);
 	let mut path_based_on_portal_exits = Vec::new();
 	// target sector and entry portal where we switch the entry portal cell to the goal
 	let mut end = path.pop().unwrap();
-	end.1 = target_grid_cell;
+	end.1 = target_field_cell;
 	// sector and field of leaving starting sector if source sector and target sector are different
 	// otherwise it was a single element path and we already removed it
 	if !path.is_empty() {
@@ -80,7 +80,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 			sectors_expanded_goals.push((*sector_id, vec![*goal]));
 		} else {
 			// portals represent the boundary to another sector, a portal can be spread over
-			// multple grid cells, expand the portal to provide multiple goal
+			// multple field cells, expand the portal to provide multiple goal
 			// targets for moving to another sector
 			let neighbour_sector_id = path[i - 1].0;
 			let g = sector_portals

--- a/examples/visualise_integration_fields.rs
+++ b/examples/visualise_integration_fields.rs
@@ -39,10 +39,10 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 		map_dimensions.get_row(),
 	);
 	//
-	let source_sector = (2, 0);
-	let source_grid_cell = (7, 3);
-	let target_sector = (0, 2);
-	let target_grid_cell = (0, 6);
+	let source_sector = SectorID::new(2, 0);
+	let source_grid_cell = FieldCell::new(7, 3);
+	let target_sector = SectorID::new(0, 2);
+	let target_grid_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(
@@ -153,7 +153,7 @@ fn setup(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					})
 					.with_children(|p| {
 						// the array area of the sector
-						let int_field = sector_int_fields.get(&(i, j));
+						let int_field = sector_int_fields.get(&SectorID::new(i, j));
 						if let Some(field) = int_field {
 							// create each column from the field
 							for array in field.get_field().iter() {

--- a/examples/visualise_portals.rs
+++ b/examples/visualise_portals.rs
@@ -21,7 +21,7 @@ struct SectorLabel(u32, u32);
 
 /// Helper component attached to each sprite, allows for the visualisation to be updated, you wouldn't use this in a real simulation
 #[derive(Component)]
-struct GridLabel(usize, usize);
+struct FieldCellLabel(usize, usize);
 
 /// Spawn sprites to represent the world
 fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
@@ -54,7 +54,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					transform: Transform::from_xyz(x, y, 0.0),
 					..default()
 				})
-				.insert(GridLabel(i, j))
+				.insert(FieldCellLabel(i, j))
 				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
@@ -71,7 +71,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 /// Spawn navigation related entities
 fn show_portals(
 	portals_q: Query<&SectorPortals>,
-	mut grid_q: Query<(&mut Handle<Image>, &GridLabel, &SectorLabel)>,
+	mut field_cell_q: Query<(&mut Handle<Image>, &FieldCellLabel, &SectorLabel)>,
 	asset_server: Res<AssetServer>,
 ) {
 	let sector_portals = portals_q.get_single().unwrap().get();
@@ -87,13 +87,13 @@ fn show_portals(
 		sector_portal_ids.insert(*sector, portal_ids);
 	}
 	// switch grid sprites to indicate portals
-	for (mut handle, grid_label, sector_label) in grid_q.iter_mut() {
+	for (mut handle, field_cell_label, sector_label) in field_cell_q.iter_mut() {
 		// lookup the sector and grid
 		if sector_portal_ids.contains_key(&SectorID::new(sector_label.0, sector_label.1)) {
 			let value = sector_portal_ids
 				.get(&SectorID::new(sector_label.0, sector_label.1))
 				.unwrap();
-			if value.contains(&(grid_label.0, grid_label.1)) {
+			if value.contains(&(field_cell_label.0, field_cell_label.1)) {
 				let new_handle: Handle<Image> = asset_server.load("ordinal_icons/portals.png");
 				*handle = new_handle;
 			}

--- a/examples/visualise_portals.rs
+++ b/examples/visualise_portals.rs
@@ -55,7 +55,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					..default()
 				})
 				.insert(GridLabel(i, j))
-				.insert(SectorLabel(sector_id.0, sector_id.1));
+				.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()));
 			}
 		}
 	}
@@ -89,9 +89,9 @@ fn show_portals(
 	// switch grid sprites to indicate portals
 	for (mut handle, grid_label, sector_label) in grid_q.iter_mut() {
 		// lookup the sector and grid
-		if sector_portal_ids.contains_key(&(sector_label.0, sector_label.1)) {
+		if sector_portal_ids.contains_key(&SectorID::new(sector_label.0, sector_label.1)) {
 			let value = sector_portal_ids
-				.get(&(sector_label.0, sector_label.1))
+				.get(&SectorID::new(sector_label.0, sector_label.1))
 				.unwrap();
 			if value.contains(&(grid_label.0, grid_label.1)) {
 				let new_handle: Handle<Image> = asset_server.load("ordinal_icons/portals.png");

--- a/justfile
+++ b/justfile
@@ -29,6 +29,24 @@ bench:
 # run a particular benchmark
 bench-one BENCH:
   cargo bench --benches --workspace --all-features {{BENCH}}
+# save each benchmark, this should be run on the main branch for comparing with your own branch
+bench-save-main:
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_route
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_flow_open
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_flow_maze
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_bundle
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_cost_fields
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_portals
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_portal_graph
+# compare each benchmark against a saved bench taken from main
+bench-compare:
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_route
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_flow_open
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_flow_maze
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_bundle
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_cost_fields
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_portals
+  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_portal_graph
 # run a debug build so the compiler can call out overflow errors etc, rather than making assumptions
 debug:
   cargo build --workspace --all-features

--- a/justfile
+++ b/justfile
@@ -31,22 +31,22 @@ bench-one BENCH:
   cargo bench --benches --workspace --all-features {{BENCH}}
 # save each benchmark, this should be run on the main branch for comparing with your own branch
 bench-save-main:
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_route
+  cargo bench -q --bench calc_route --workspace --all-features -- --save-baseline main_calc_route
   cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_flow_open
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_calc_flow_maze
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_bundle
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_cost_fields
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_portals
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --save-baseline main_init_portal_graph
+  cargo bench -q --bench calc_flow_maze --workspace --all-features -- --save-baseline main_calc_flow_maze
+  cargo bench -q --bench init_bundle --workspace --all-features -- --save-baseline main_init_bundle
+  cargo bench -q --bench init_cost_fields --workspace --all-features -- --save-baseline main_init_cost_fields
+  cargo bench -q --bench init_portals --workspace --all-features -- --save-baseline main_init_portals
+  cargo bench -q --bench init_portal_graph --workspace --all-features -- --save-baseline main_init_portal_graph
 # compare each benchmark against a saved bench taken from main
 bench-compare:
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_route
+  cargo bench -q --bench calc_route --workspace --all-features -- --baseline main_calc_route
   cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_flow_open
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_calc_flow_maze
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_bundle
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_cost_fields
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_portals
-  cargo bench -q --bench calc_flow_open --workspace --all-features -- --baseline main_init_portal_graph
+  cargo bench -q --bench calc_flow_maze --workspace --all-features -- --baseline main_calc_flow_maze
+  cargo bench -q --bench init_bundle --workspace --all-features -- --baseline main_init_bundle
+  cargo bench -q --bench init_cost_fields --workspace --all-features -- --baseline main_init_cost_fields
+  cargo bench -q --bench init_portals --workspace --all-features -- --baseline main_init_portals
+  cargo bench -q --bench init_portal_graph --workspace --all-features -- --baseline main_init_portal_graph
 # run a debug build so the compiler can call out overflow errors etc, rather than making assumptions
 debug:
   cargo build --workspace --all-features

--- a/src/flowfields/fields/cost_field.rs
+++ b/src/flowfields/fields/cost_field.rs
@@ -1,6 +1,6 @@
 //! The CostField contains a 2D array of 8-bit values. The values correspond to the cost of that
-//! grid in the array. A value of 1 is the default, a value of 255 is a special case that idicates
-//! that the grid cell is strictly forbidden from being used in a pathing calculation (effectively
+//! cell in the array. A value of 1 is the default, a value of 255 is a special case that idicates
+//! that the field cell is strictly forbidden from being used in a pathing calculation (effectively
 //! saying there is a wall or cliff/impassable terrain there). Any other value indicates a harder
 //! cost of movement which could be from a slope or marshland or others.
 //!
@@ -60,17 +60,17 @@ impl Field<u8> for CostField {
 	fn get_field(&self) -> &[[u8; FIELD_RESOLUTION]; FIELD_RESOLUTION] {
 		&self.0
 	}
-	/// Retrieve a grid cell value
-	fn get_grid_value(&self, field_cell: FieldCell) -> u8 {
+	/// Retrieve a field cell value
+	fn get_field_cell_value(&self, field_cell: FieldCell) -> u8 {
 		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
-			panic!("Cannot get a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
+			panic!("Cannot get a CostField value, index out of bounds. Asked for column {}, row {}, field column length is {}, field row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
 		self.0[field_cell.get_column()][field_cell.get_row()]
 	}
-	/// Set a grid cell to a value
-	fn set_grid_value(&mut self, value: u8, field_cell: FieldCell) {
+	/// Set a field cell to a value
+	fn set_field_cell_value(&mut self, value: u8, field_cell: FieldCell) {
 		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
-			panic!("Cannot set a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
+			panic!("Cannot set a CostField value, index out of bounds. Asked for column {}, row {}, field column length is {}, field row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
 		self.0[field_cell.get_column()][field_cell.get_row()] = value;
 	}
@@ -109,7 +109,7 @@ impl CostField {
 					if *n == target {
 						return (true, steps_taken);
 					}
-					let cell_cost = cost_field.get_grid_value(*n);
+					let cell_cost = cost_field.get_field_cell_value(*n);
 					// ignore impassable cells
 					if cell_cost != 255 && !visited.contains(n) {
 						// keep exploring
@@ -145,8 +145,8 @@ mod tests {
 	fn get_cost_field_value() {
 		let mut cost_field = CostField::default();
 		let field_cell = FieldCell::new(9, 9);
-		cost_field.set_grid_value(255, field_cell);
-		let result = cost_field.get_grid_value(field_cell);
+		cost_field.set_field_cell_value(255, field_cell);
+		let result = cost_field.get_field_cell_value(field_cell);
 		let actual: u8 = 255;
 		assert_eq!(actual, result);
 	}
@@ -170,10 +170,10 @@ mod tests {
 		// |__|__|__|__|__|x_|__|__|__|__|
 		// |__|__|__|__|__|x_|P_|__|__|__|
 		let mut cost_field = CostField::default();
-		cost_field.set_grid_value(255, FieldCell::new(5, 9));
-		cost_field.set_grid_value(255, FieldCell::new(5, 8));
-		cost_field.set_grid_value(255, FieldCell::new(5, 7));
-		cost_field.set_grid_value(255, FieldCell::new(6, 7));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 8));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 7));
+		cost_field.set_field_cell_value(255, FieldCell::new(6, 7));
 		let source = FieldCell::new(0, 4);
 		let target = FieldCell::new(6, 9);
 
@@ -196,13 +196,13 @@ mod tests {
 		// |__|__|__|__|__|x_|__|x_|__|__|
 		// |__|__|__|__|__|x_|P_|x_|__|__|
 		let mut cost_field = CostField::default();
-		cost_field.set_grid_value(255, FieldCell::new(5, 9));
-		cost_field.set_grid_value(255, FieldCell::new(5, 8));
-		cost_field.set_grid_value(255, FieldCell::new(5, 7));
-		cost_field.set_grid_value(255, FieldCell::new(6, 7));
-		cost_field.set_grid_value(255, FieldCell::new(7, 7));
-		cost_field.set_grid_value(255, FieldCell::new(7, 8));
-		cost_field.set_grid_value(255, FieldCell::new(7, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 8));
+		cost_field.set_field_cell_value(255, FieldCell::new(5, 7));
+		cost_field.set_field_cell_value(255, FieldCell::new(6, 7));
+		cost_field.set_field_cell_value(255, FieldCell::new(7, 7));
+		cost_field.set_field_cell_value(255, FieldCell::new(7, 8));
+		cost_field.set_field_cell_value(255, FieldCell::new(7, 9));
 		let source = FieldCell::new(0, 4);
 		let target = FieldCell::new(6, 9);
 

--- a/src/flowfields/fields/cost_field.rs
+++ b/src/flowfields/fields/cost_field.rs
@@ -61,26 +61,26 @@ impl Field<u8> for CostField {
 		&self.0
 	}
 	/// Retrieve a grid cell value
-	fn get_grid_value(&self, column: usize, row: usize) -> u8 {
-		if column >= self.0.len() || row >= self.0[0].len() {
-			panic!("Cannot get a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", column, row, self.0.len(), self.0[0].len())
+	fn get_grid_value(&self, field_cell: FieldCell) -> u8 {
+		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
+			panic!("Cannot get a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
-		self.0[column][row]
+		self.0[field_cell.get_column()][field_cell.get_row()]
 	}
 	/// Set a grid cell to a value
-	fn set_grid_value(&mut self, value: u8, column: usize, row: usize) {
-		if column >= self.0.len() || row >= self.0[0].len() {
-			panic!("Cannot set a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", column, row, self.0.len(), self.0[0].len())
+	fn set_grid_value(&mut self, value: u8, field_cell: FieldCell) {
+		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
+			panic!("Cannot set a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
-		self.0[column][row] = value;
+		self.0[field_cell.get_column()][field_cell.get_row()] = value;
 	}
 }
 impl CostField {
 	/// Tests whether two portals can see each other within a sector (one might be boxed in by impassable cost field values), additionally returns the number of steps taken to find a route between the two - this can be used as an edge weight
 	pub fn can_internal_portal_pair_see_each_other(
 		&self,
-		source: (usize, usize),
-		target: (usize, usize),
+		source: FieldCell,
+		target: FieldCell,
 	) -> (bool, i32) {
 		// instance of corner portals overlapping from cramped world
 		if source == target {
@@ -92,9 +92,9 @@ impl CostField {
 		let is_routable = process_neighbours(target, queue, visited, self, 0);
 		/// Recursively process the cells to see if there's a path
 		fn process_neighbours(
-			target: (usize, usize),
-			queue: Vec<(usize, usize)>,
-			mut visited: HashSet<(usize, usize)>,
+			target: FieldCell,
+			queue: Vec<FieldCell>,
+			mut visited: HashSet<FieldCell>,
 			cost_field: &CostField,
 			mut steps_taken: i32,
 		) -> (bool, i32) {
@@ -109,11 +109,11 @@ impl CostField {
 					if *n == target {
 						return (true, steps_taken);
 					}
-					let cell_cost = cost_field.get_grid_value(n.0, n.1);
+					let cell_cost = cost_field.get_grid_value(*n);
 					// ignore impassable cells
-					if cell_cost != 255 && !visited.contains(&(n.0, n.1)) {
+					if cell_cost != 255 && !visited.contains(n) {
 						// keep exploring
-						next_neighbours.push((n.0, n.1));
+						next_neighbours.push(*n);
 					}
 				}
 			}
@@ -144,8 +144,9 @@ mod tests {
 	#[test]
 	fn get_cost_field_value() {
 		let mut cost_field = CostField::default();
-		cost_field.set_grid_value(255, 9, 9);
-		let result = cost_field.get_grid_value(9, 9);
+		let field_cell = FieldCell::new(9, 9);
+		cost_field.set_grid_value(255, field_cell);
+		let result = cost_field.get_grid_value(field_cell);
 		let actual: u8 = 255;
 		assert_eq!(actual, result);
 	}
@@ -169,12 +170,12 @@ mod tests {
 		// |__|__|__|__|__|x_|__|__|__|__|
 		// |__|__|__|__|__|x_|P_|__|__|__|
 		let mut cost_field = CostField::default();
-		cost_field.set_grid_value(255, 5, 9);
-		cost_field.set_grid_value(255, 5, 8);
-		cost_field.set_grid_value(255, 5, 7);
-		cost_field.set_grid_value(255, 6, 7);
-		let source = (0, 4);
-		let target = (6, 9);
+		cost_field.set_grid_value(255, FieldCell::new(5, 9));
+		cost_field.set_grid_value(255, FieldCell::new(5, 8));
+		cost_field.set_grid_value(255, FieldCell::new(5, 7));
+		cost_field.set_grid_value(255, FieldCell::new(6, 7));
+		let source = FieldCell::new(0, 4);
+		let target = FieldCell::new(6, 9);
 
 		let result = cost_field.can_internal_portal_pair_see_each_other(source, target);
 
@@ -195,15 +196,15 @@ mod tests {
 		// |__|__|__|__|__|x_|__|x_|__|__|
 		// |__|__|__|__|__|x_|P_|x_|__|__|
 		let mut cost_field = CostField::default();
-		cost_field.set_grid_value(255, 5, 9);
-		cost_field.set_grid_value(255, 5, 8);
-		cost_field.set_grid_value(255, 5, 7);
-		cost_field.set_grid_value(255, 6, 7);
-		cost_field.set_grid_value(255, 7, 7);
-		cost_field.set_grid_value(255, 7, 8);
-		cost_field.set_grid_value(255, 7, 9);
-		let source = (0, 4);
-		let target = (6, 9);
+		cost_field.set_grid_value(255, FieldCell::new(5, 9));
+		cost_field.set_grid_value(255, FieldCell::new(5, 8));
+		cost_field.set_grid_value(255, FieldCell::new(5, 7));
+		cost_field.set_grid_value(255, FieldCell::new(6, 7));
+		cost_field.set_grid_value(255, FieldCell::new(7, 7));
+		cost_field.set_grid_value(255, FieldCell::new(7, 8));
+		cost_field.set_grid_value(255, FieldCell::new(7, 9));
+		let source = FieldCell::new(0, 4);
+		let target = FieldCell::new(6, 9);
 
 		let result = cost_field.can_internal_portal_pair_see_each_other(source, target);
 

--- a/src/flowfields/fields/flow_field.rs
+++ b/src/flowfields/fields/flow_field.rs
@@ -64,26 +64,26 @@ impl Field<u8> for FlowField {
 	fn get_field(&self) -> &[[u8; FIELD_RESOLUTION]; FIELD_RESOLUTION] {
 		&self.0
 	}
-	/// Retrieve a grid cell value
-	fn get_grid_value(&self, column: usize, row: usize) -> u8 {
-		if column >= self.0.len() || row >= self.0[0].len() {
-			panic!("Cannot get a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", column, row, self.0.len(), self.0[0].len())
+	/// Retrieve a field cell value
+	fn get_grid_value(&self, field_cell: FieldCell) -> u8 {
+		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
+			panic!("Cannot get a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
-		self.0[column][row]
+		self.0[field_cell.get_column()][field_cell.get_row()]
 	}
-	/// Set a grid cell to a value
-	fn set_grid_value(&mut self, value: u8, column: usize, row: usize) {
-		if column >= self.0.len() || row >= self.0[0].len() {
-			panic!("Cannot set a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", column, row, self.0.len(), self.0[0].len())
+	/// Set a field cell to a value
+	fn set_grid_value(&mut self, value: u8, field_cell: FieldCell) {
+		if field_cell.get_column() >= self.0.len() || field_cell.get_row() >= self.0[0].len() {
+			panic!("Cannot set a CostField grid value, index out of bounds. Asked for column {}, row {}, grid column length is {}, grid row length is {}", field_cell.get_column(), field_cell.get_row(), self.0.len(), self.0[0].len())
 		}
-		self.0[column][row] = value;
+		self.0[field_cell.get_column()][field_cell.get_row()] = value;
 	}
 }
 impl FlowField {
 	/// Calculate the [FlowField] from an [IntegrationField], additionally for a sector in a chain of sectors along a path this will peak into the previous sectors [IntegrationField] to apply a directional optimisation to this sector's [FlowField]
 	pub fn calculate(
 		&mut self,
-		goals: &[(usize, usize)],
+		goals: &[FieldCell],
 		previous_sector_ord_int: Option<(Ordinal, &IntegrationField)>,
 		integration_field: &IntegrationField,
 	) {
@@ -107,41 +107,41 @@ impl FlowField {
 					let mut value = 0;
 					value |= BITS_PORTAL_GOAL;
 					value |= ordinal_bits;
-					self.set_grid_value(value, goal.0, goal.1);
+					self.set_grid_value(value, *goal);
 				} //TODO this sould never ever be none...
 			}
 		} else {
 			// set goal cells
-			self.set_grid_value(BITS_GOAL, goals[0].0, goals[0].1);
+			self.set_grid_value(BITS_GOAL, goals[0]);
 		}
 
 		for (i, column) in integration_field.get_field().iter().enumerate() {
 			for (j, _row) in column.iter().enumerate() {
-				if self.get_grid_value(i, j) == BITS_DEFAULT {
-					let current_cost = integration_field.get_grid_value(i, j);
+				if self.get_grid_value(FieldCell::new(i, j)) == BITS_DEFAULT {
+					let current_cost = integration_field.get_grid_value(FieldCell::new(i, j));
 					// mark impassable //TODO maybe skip? waste of time perhaps
 					if current_cost == u16::MAX {
-						self.set_grid_value(BITS_ZERO, i, j);
+						self.set_grid_value(BITS_ZERO, FieldCell::new(i, j));
 					} else if current_cost != 0 {
 						// skip goals of zero
 						// store the cheapest node
 						let mut cheapest_value = u16::MAX;
 						let mut cheapest_neighbour = None;
-						let neighbours = Ordinal::get_all_cell_neighbours((i, j));
+						let neighbours = Ordinal::get_all_cell_neighbours(FieldCell::new(i, j));
 						for n in neighbours.iter() {
-							let neighbour_cost = integration_field.get_grid_value(n.0, n.1);
+							let neighbour_cost = integration_field.get_grid_value(*n);
 							if neighbour_cost < cheapest_value {
 								cheapest_value = neighbour_cost;
 								cheapest_neighbour = Some(n);
 							}
 						}
 						if let Some(target) = cheapest_neighbour {
-							let ord = Ordinal::cell_to_cell_direction(*target, (i, j));
+							let ord = Ordinal::cell_to_cell_direction(*target, FieldCell::new(i, j));
 							let bit_ord = convert_ordinal_to_bits_dir(ord);
 							let mut value = 0;
 							value |= bit_ord;
 							value |= BITS_PATHABLE;
-							self.set_grid_value(value, i, j);
+							self.set_grid_value(value, FieldCell::new(i, j));
 						} //TODO this should never ever be none...
 					}
 				}
@@ -151,7 +151,7 @@ impl FlowField {
 }
 /// Used by a [FlowField] calculation that needs to peek into the previous sectors [IntegrationField] to align portal goal directional bits to the most optimal integration costs
 fn lookup_portal_goal_neighbour_costs_in_previous_sector(
-	portal_goal: &(usize, usize),
+	portal_goal: &FieldCell,
 	previous_integration_field: &IntegrationField,
 	sector_ordinal: Ordinal,
 ) -> Vec<(Ordinal, u16)> {
@@ -159,72 +159,72 @@ fn lookup_portal_goal_neighbour_costs_in_previous_sector(
 	match sector_ordinal {
 		Ordinal::North => {
 			// orthogonal adjacent cost
-			let adj_pos = (portal_goal.0, 9);
+			let adj_pos = (portal_goal.get_column(), 9);
 			let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 			adjacent_neighbours.push((Ordinal::North, adj_cost));
 			// try and get a cost left
-			if portal_goal.0 > 0 {
-				let adj_pos = (portal_goal.0 - 1, 9);
+			if portal_goal.get_column() > 0 {
+				let adj_pos = (portal_goal.get_column() - 1, 9);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::NorthWest, adj_cost));
 			}
 			// try and get a cost right
-			if portal_goal.0 < FIELD_RESOLUTION - 1 {
-				let adj_pos = (portal_goal.0 + 1, 9);
+			if portal_goal.get_column() < FIELD_RESOLUTION - 1 {
+				let adj_pos = (portal_goal.get_column() + 1, 9);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::NorthEast, adj_cost));
 			}
 		}
 		Ordinal::East => {
 			// orthogonal adjacent cost
-			let adj_pos = (0, portal_goal.1);
+			let adj_pos = (0, portal_goal.get_row());
 			let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 			adjacent_neighbours.push((Ordinal::East, adj_cost));
 			// try and get a cost above
-			if portal_goal.1 > 0 {
-				let adj_pos = (0, portal_goal.1 - 1);
+			if portal_goal.get_row() > 0 {
+				let adj_pos = (0, portal_goal.get_row() - 1);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::NorthEast, adj_cost));
 			}
 			// try and get a cost below
-			if portal_goal.1 < FIELD_RESOLUTION - 1 {
-				let adj_pos = (0, portal_goal.1 + 1);
+			if portal_goal.get_row() < FIELD_RESOLUTION - 1 {
+				let adj_pos = (0, portal_goal.get_row() + 1);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::SouthEast, adj_cost));
 			}
 		}
 		Ordinal::South => {
 			// orthogonal adjacent cost
-			let adj_pos = (portal_goal.0, 0);
+			let adj_pos = (portal_goal.get_column(), 0);
 			let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 			adjacent_neighbours.push((Ordinal::South, adj_cost));
 			// try and get a cost left
-			if portal_goal.0 > 0 {
-				let adj_pos = (portal_goal.0 - 1, 0);
+			if portal_goal.get_column() > 0 {
+				let adj_pos = (portal_goal.get_column() - 1, 0);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::SouthWest, adj_cost));
 			}
 			// try and get a cost right
-			if portal_goal.0 < FIELD_RESOLUTION - 1 {
-				let adj_pos = (portal_goal.0 + 1, 0);
+			if portal_goal.get_column() < FIELD_RESOLUTION - 1 {
+				let adj_pos = (portal_goal.get_column() + 1, 0);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::SouthEast, adj_cost));
 			}
 		}
 		Ordinal::West => {
 			// orthogonal adjacent cost
-			let adj_pos = (9, portal_goal.1);
+			let adj_pos = (9, portal_goal.get_row());
 			let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 			adjacent_neighbours.push((Ordinal::West, adj_cost));
 			// try and get a cost above
-			if portal_goal.1 > 0 {
-				let adj_pos = (9, portal_goal.1 - 1);
+			if portal_goal.get_row() > 0 {
+				let adj_pos = (9, portal_goal.get_row() - 1);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::NorthWest, adj_cost));
 			}
 			// try and get a cost below
-			if portal_goal.1 < FIELD_RESOLUTION - 1 {
-				let adj_pos = (9, portal_goal.1 + 1);
+			if portal_goal.get_row() < FIELD_RESOLUTION - 1 {
+				let adj_pos = (9, portal_goal.get_row() + 1);
 				let adj_cost = previous_integration_field.get_field()[adj_pos.0][adj_pos.1];
 				adjacent_neighbours.push((Ordinal::SouthWest, adj_cost));
 			}
@@ -319,7 +319,7 @@ mod tests {
 	#[test]
 	fn default_init() {
 		let flow_field = FlowField::default();
-		let v = flow_field.get_grid_value(0, 0);
+		let v = flow_field.get_grid_value(FieldCell::new(0, 0));
 		assert_eq!(BITS_DEFAULT, v);
 	}
 	#[test]
@@ -328,16 +328,16 @@ mod tests {
 		// int field pair pointing towards goal in orthognal west direction
 		let ordinal_to_previous_sector = Ordinal::South;
 		let goals = vec![
-			(0, 9),
-			(1, 9),
-			(2, 9),
-			(3, 9),
-			(4, 9),
-			(5, 9),
-			(6, 9),
-			(7, 9),
-			(8, 9),
-			(9, 9),
+			FieldCell::new(0, 9),
+			FieldCell::new(1, 9),
+			FieldCell::new(2, 9),
+			FieldCell::new(3, 9),
+			FieldCell::new(4, 9),
+			FieldCell::new(5, 9),
+			FieldCell::new(6, 9),
+			FieldCell::new(7, 9),
+			FieldCell::new(8, 9),
+			FieldCell::new(9, 9),
 		];
 		let mut previous_int_field = IntegrationField::new(&goals);
 		previous_int_field.calculate_field(&goals, &cost_field);
@@ -366,16 +366,16 @@ mod tests {
 		// int field pair pointing towards goal in orthognal west direction
 		let ordinal_to_previous_sector = Ordinal::West;
 		let goals = vec![
-			(0, 0),
-			(0, 1),
-			(0, 2),
-			(0, 3),
-			(0, 4),
-			(0, 5),
-			(0, 6),
-			(0, 7),
-			(0, 8),
-			(0, 9),
+			FieldCell::new(0, 0),
+			FieldCell::new(0, 1),
+			FieldCell::new(0, 2),
+			FieldCell::new(0, 3),
+			FieldCell::new(0, 4),
+			FieldCell::new(0, 5),
+			FieldCell::new(0, 6),
+			FieldCell::new(0, 7),
+			FieldCell::new(0, 8),
+			FieldCell::new(0, 9),
 		];
 		let mut previous_int_field = IntegrationField::new(&goals);
 		previous_int_field.calculate_field(&goals, &cost_field);

--- a/src/flowfields/fields/mod.rs
+++ b/src/flowfields/fields/mod.rs
@@ -15,10 +15,10 @@ use bevy::utils::Duration;
 pub trait Field<T> {
 	/// Get a reference to the field array
 	fn get_field(&self) -> &[[T; FIELD_RESOLUTION]; FIELD_RESOLUTION];
-	/// Retrieve a grid cell value
-	fn get_grid_value(&self, field_cell: FieldCell) -> T;
-	/// Set a grid cell to a value
-	fn set_grid_value(&mut self, value: T, field_cell: FieldCell);
+	/// Retrieve a field cell value
+	fn get_field_cell_value(&self, field_cell: FieldCell) -> T;
+	/// Set a field cell to a value
+	fn set_field_cell_value(&mut self, value: T, field_cell: FieldCell);
 }
 
 /// ID of a cell within a field
@@ -52,7 +52,7 @@ pub struct RouteMetadata {
 	source_sector: SectorID,
 	/// Sector to find a route to
 	target_sector: SectorID,
-	/// Field/grid cell of the goal in the target sector
+	/// Field cell of the goal in the target sector
 	target_goal: FieldCell,
 	//? If a game is running for 136 years bad things will start happening here
 	/// Marks the route based on time elapsed since app start, used to enable automatic cleardown of long lived routes that are probably not needed anymore
@@ -103,23 +103,19 @@ impl RouteMetadata {
 	}
 }
 /// Each key makes use of custom Ord and Eq implementations based on comparing `(source_id, target_id, goal_id)` so that RouteMetaData can be used to refer to the high-level route an actor has asked for. The value is a list of `(sector_id, goal_id)` referring to the sector-portal (or just the end goal) route. An actor can use this as a fallback if the `field_cache` doesn't yet contain the granular [FlowField] routes or for when [CostField]s have been changed and so [FlowField]s in the cache need to be regenerated
-#[allow(clippy::type_complexity)]
 #[derive(Component, Default, Clone)]
 pub struct RouteCache(BTreeMap<RouteMetadata, Vec<(SectorID, FieldCell)>>);
 
 impl RouteCache {
 	/// Get the map of routes
-	#[allow(clippy::type_complexity)]
 	pub fn get(&self) -> &BTreeMap<RouteMetadata, Vec<(SectorID, FieldCell)>> {
 		&self.0
 	}
 	/// Get a mutable reference to the map of routes
-	#[allow(clippy::type_complexity)]
 	pub fn get_mut(&mut self) -> &mut BTreeMap<RouteMetadata, Vec<(SectorID, FieldCell)>> {
 		&mut self.0
 	}
 	/// Get a high-level sector to sector route. Returns [None] if it doesn't exist
-	#[allow(clippy::type_complexity)]
 	pub fn get_route(
 		&self,
 		source_sector: SectorID,

--- a/src/flowfields/mod.rs
+++ b/src/flowfields/mod.rs
@@ -12,8 +12,8 @@
 //! * FlowField - a 2D array built from the `IntegrationField` which decribes how an actor should move (flow) across the world
 //! * FlowField Cache - a means of storing `FlowFields` allowing multiple actors to use and reuse them
 //! * Ordinal - a direction based on traditional compass ordinals: N, NE, E, SE, S, SW, W, NW. Used for discovery of Sectors/field cells at various points within the algorithm
-//! * Grid cell - an element of a 2D array
-//! * Goal - the target grid cell an actor needs to path to
+//! * Field cell - an element of a 2D array
+//! * Goal - the target field cell an actor needs to path to
 //! * Portal goal - a target point within a sector that allows an actor to transition to another sector, thus bringing it closer towards/to the goal
 //!
 //! ## Sector
@@ -22,7 +22,7 @@
 //!
 //! ## CostField
 //!
-//! A `CostField` is an `MxN` 2D array of 8-bit values. The values indicate the `cost` of navigating through that cell of the grid. A value of `1` is the default and indicates the easiest `cost`, and a value of `255` is a special value used to indicate that the grid cell is impassable - this could be used to indicate a wall or obstacle. All other values from `2-254` represent increasing cost, for instance a slope or difficult terrain such as a marsh. The idea is that the pathfinding calculations will favour cells with a smaller value before any others.
+//! A `CostField` is an `MxN` 2D array of 8-bit values. The values indicate the `cost` of navigating through that cell of the field. A value of `1` is the default and indicates the easiest `cost`, and a value of `255` is a special value used to indicate that the field cell is impassable - this could be used to indicate a wall or obstacle. All other values from `2-254` represent increasing cost, for instance a slope or difficult terrain such as a marsh. The idea is that the pathfinding calculations will favour cells with a smaller value before any others.
 //!
 //!
 //! ## Portals
@@ -37,18 +37,18 @@
 //! * For each sector create `edges` (pathable routes) to and from each Portal `node` - effectively create internal walkable routes of each sector
 //! * Create `edges` across the Portal `node` on all sector boundaries (walkable route from one sector to another)
 //!
-//! This allows the graph to be queried with a `source` sector and a `target` sector and a list of Portals are returned which can be pathed. When a `CostField` is changed this triggers the regeneration of the sector Portals for the region that `CostField` resides in (and its neighbours to ensure homogenous boundaries) and the graph is updated with any new Portals `nodes` and the old ones are removed. This is a particularly difficult and complicated area as the Sectors, Portals and fields are represented in 2D arrays but the graph is effectively 1D - it's a big long list of `nodes`. To handle identifying a graph `node` from a Sector and field grid cell a special data field exists in `PortalGraph` nicknamed the "translator". It's a way of being able to convert between the graph data structure and the 2D data structure back and forth, so from a grid cell you can find its `node` and from a list of `nodes` (like an A* result) you can find the location of each Portal in the grids.
+//! This allows the graph to be queried with a `source` sector and a `target` sector and a list of Portals are returned which can be pathed. When a `CostField` is changed this triggers the regeneration of the sector Portals for the region that `CostField` resides in (and its neighbours to ensure homogenous boundaries) and the graph is updated with any new Portals `nodes` and the old ones are removed. This is a particularly difficult and complicated area as the Sectors, Portals and fields are represented in 2D arrays but the graph is effectively 1D - it's a big long list of `nodes`. To handle identifying a graph `node` from a Sector and field field cell a special data field exists in `PortalGraph` nicknamed the "translator". It's a way of being able to convert between the graph data structure and the 2D data structure back and forth, so from a field cell you can find its `node` and from a list of `nodes` (like an A* result) you can find the location of each Portal in the fields.
 //!
 //! ## IntegrationField
 //!
 //! An `IntegrationField` is an `MxN` 2D array of 16-bit values. It uses the `CostField` to produce a cumulative cost to reach the end goal/target. It's an ephemeral field, as in it gets built for a required sector and then consumed by the `FlowField` calculation.
 //!
-//! When a new route needs to be processed the field values are set to `u16::MAX` and the grid cell containing the goal is set to `0`.
+//! When a new route needs to be processed the field values are set to `u16::MAX` and the field cell containing the goal is set to `0`.
 //!
 //! A series of passes are performed from the goal as an expanding wavefront calculating the field values:
 //!
 //! * The valid ordinal neighbours of the goal are determined (North, East, South, West - when not against a sector/world boundary)
-//! * For each ordinal grid cell lookup their `CostField` value
+//! * For each ordinal field cell lookup their `CostField` value
 //! * Add the `CostField` cost to the `IntegrationFields` cost of the current cell (at the beginning this is the goal int cost `0`)
 //! * Propagate to the next neighbours, find their ordinals and repeat adding their cost value to to the current cells integration cost to produce their cumulative integration cost, and repeat until the entire field is done
 //!

--- a/src/flowfields/portal/portal_graph.rs
+++ b/src/flowfields/portal/portal_graph.rs
@@ -136,7 +136,7 @@ impl PortalGraph {
 				}
 			}
 		}
-		// convert the grid cell positions to [NodeIndex]
+		// convert the field cell positions to [NodeIndex]
 		let mut node_indices_to_edge = Vec::new();
 		for (pair, cost) in visible_pairs_with_cost.iter() {
 			let source_index = find_index_from_single_portal_and_portal_cell(
@@ -364,7 +364,7 @@ impl PortalGraph {
 		}
 		path
 	}
-	/// From any grid cell at a `source` sector find any pathable portals witihn that sector and generate a path from each portal to the target. Compare the results and return the path with the best cost associated with it
+	/// From any field cell at a `source` sector find any pathable portals witihn that sector and generate a path from each portal to the target. Compare the results and return the path with the best cost associated with it
 	pub fn find_best_path(
 		&self,
 		source: (SectorID, FieldCell),
@@ -374,7 +374,7 @@ impl PortalGraph {
 	) -> Option<(i32, Vec<NodeIndex>)> {
 		// find portals reachable by the source actor position
 		let source_sector_id = source.0;
-		let source_grid_cell = source.1;
+		let source_field_cell = source.1;
 		let mut source_portals = Vec::new();
 		let portals = sector_portals.get().get(&source_sector_id).unwrap();
 		for ordinal in portals.get().iter() {
@@ -382,7 +382,7 @@ impl PortalGraph {
 				let cost_field = sector_cost_fields.get().get(&source_sector_id).unwrap();
 				if cost_field
 					.can_internal_portal_pair_see_each_other(
-						source_grid_cell,
+						source_field_cell,
 						*cell,
 					)
 					.0
@@ -393,7 +393,7 @@ impl PortalGraph {
 		}
 		// find portals that can reach the target/goal
 		let target_sector_id = target.0;
-		let target_grid_cell = target.1;
+		let target_field_cell = target.1;
 		let mut target_portals = Vec::new();
 		let portals = sector_portals.get().get(&target_sector_id).unwrap();
 		for ordinal in portals.get().iter() {
@@ -401,7 +401,7 @@ impl PortalGraph {
 				let cost_field = sector_cost_fields.get().get(&target_sector_id).unwrap();
 				if cost_field
 					.can_internal_portal_pair_see_each_other(
-						target_grid_cell,
+						target_field_cell,
 						*cell,
 					)
 					.0
@@ -449,8 +449,8 @@ impl PortalGraph {
 	// 	}
 	// 	None
 	// }
-	/// Iterate over the "translator" (`self.node_index_translation`) and search for a portal node of
-	/// `search_index` and identify the sector it resides in and the cell grid
+	/// Iterate over the "translator" (`self.node_index_translation`) and search for a field cell of
+	/// `search_index` and identify the sector it resides in and the cell
 	/// position of it within that sector
 	fn find_portal_sector_id_and_cell_position_from_graph_index(
 		&self,
@@ -496,7 +496,7 @@ impl PortalGraph {
 		}
 		None
 	}
-	// /// Iterate through the [Portals] [Ordinal] lists to locate the graph positional indices of a particular grid portal position, these indices are then used to find the  [NodeIndex] from its recorded position in the "translator" (`self.node_index_translation`)
+	// /// Iterate through the [Portals] [Ordinal] lists to locate the graph positional indices of a particular field portal position, these indices are then used to find the  [NodeIndex] from its recorded position in the "translator" (`self.node_index_translation`)
 	// fn find_index_from_single_portal_and_portal_cell(
 	// 	&self,
 	// 	portals: &Portals,
@@ -517,7 +517,7 @@ impl PortalGraph {
 	// }
 }
 
-/// Iterate through the [Portals] [Ordinal] lists to locate the graph positional indices of a particular grid portal position, these indices are then used to find the  [NodeIndex] from its recorded position in the "translator" (`self.node_index_translation`)
+/// Iterate through the [Portals] [Ordinal] lists to locate the graph positional indices of a particular field portal position, these indices are then used to find the  [NodeIndex] from its recorded position in the "translator" (`self.node_index_translation`)
 fn find_index_from_single_portal_and_portal_cell(
 	translator: &BTreeMap<SectorID, [Vec<NodeIndex>; 4]>,
 	portals: &Portals,
@@ -698,7 +698,7 @@ use super::*;
 		// update the top-left CostFields and calculate new portals
 		let mutated_sector_id = SectorID::new(0, 0);
 		let field = sector_cost_fields.get_mut().get_mut(&mutated_sector_id).unwrap();
-		field.set_grid_value(255, FieldCell::new(4, 9));
+		field.set_field_cell_value(255, FieldCell::new(4, 9));
 		sector_portals.update_portals(mutated_sector_id, &sector_cost_fields, map_x_dimension, map_z_dimension);
 
 		// This produces a new representation with an extra portal, `x` denotes the impassable point
@@ -744,7 +744,7 @@ use super::*;
 	// 	// update the top-left CostFields and calculate new portals
 	// 	let mutated_sector_id = (0, 0);
 	// 	let field = sector_cost_fields.get_mut().get_mut(&mutated_sector_id).unwrap();
-	// 	field.set_grid_value(255, 4, 9);
+	// 	field.set_field_cell_value(255, 4, 9);
 	// 	sector_portals.update_portals(mutated_sector_id, &sector_cost_fields, map_x_dimension, map_z_dimension);
 
 	// 	// build the graph

--- a/src/flowfields/portal/portal_graph.rs
+++ b/src/flowfields/portal/portal_graph.rs
@@ -16,7 +16,7 @@ use petgraph::{
 
 use crate::prelude::*;
 
-use super::portals::{PortalNode, Portals};
+use super::portals::Portals;
 
 /// Each sector contains a series of Portals. A [StableGraph] allows a route to be calculated from one
 /// sector to another via the portal boundaries.
@@ -32,13 +32,14 @@ use super::portals::{PortalNode, Portals};
 pub struct PortalGraph {
 	/// The graph for storing nodes and edges
 	graph: StableGraph<u32, i32, petgraph::Directed>,
-	/// The `graph` cannot store [PortalNode]s directly instead it records entries with a [NodeIndex].
-	/// Based on the vectors of each sector in [SectorPortals] we create a means of storing
-	/// [NodeIndex] in an identical structure to [Portals]. This allows a [PortalNode] to be
+	/// The `graph` cannot store portal [FieldCell]s directly instead it
+	/// records entries with a [NodeIndex]. Based on the vectors of each sector
+	/// in [SectorPortals] we create a means of storing [NodeIndex] in an
+	/// identical structure to [Portals]. This allows a portal [FieldCell] to be
 	/// mapped to a [NodeIndex] and vice versa.
 	///
 	/// The keys of the map correspond to the unique IDs of Sectors and the values are an [Ordinal] list structure which should be identical in structure for each sectors [Portals]
-	node_index_translation: BTreeMap<(u32, u32), [Vec<NodeIndex>; 4]>,
+	node_index_translation: BTreeMap<SectorID, [Vec<NodeIndex>; 4]>,
 }
 //TODO need a means of chekcing graph capacity, if it's near usize, usize then rebuild it from scrtach to reset size
 impl PortalGraph {
@@ -62,8 +63,8 @@ impl PortalGraph {
 		}
 		self
 	}
-	/// For the given Sector [Portals] add a node to the graph for each [PortalNode]
-	fn build_sector_nodes(&mut self, sector_id: &(u32, u32), portals: &Portals) -> &mut Self {
+	/// For the given Sector [Portals] add a node to the graph for each portal [FieldCell]
+	fn build_sector_nodes(&mut self, sector_id: &SectorID, portals: &Portals) -> &mut Self {
 		let graph = &mut self.graph;
 		let translator = &mut self.node_index_translation;
 		// initialise the sector within the translator
@@ -106,7 +107,7 @@ impl PortalGraph {
 	/// Create graph edges between each portal of the Sector
 	fn build_internal_sector_edges(
 		&mut self,
-		sector_id: &(u32, u32),
+		sector_id: &SectorID,
 		portals: &Portals,
 		cost_field: &CostField,
 	) -> &mut Self {
@@ -119,10 +120,7 @@ impl PortalGraph {
 			.iter()
 			.flatten()
 			.cloned()
-			.collect::<Vec<PortalNode>>()
-			.iter()
-			.map(|&x| x.get_column_row())
-			.collect::<Vec<(usize, usize)>>();
+			.collect::<Vec<FieldCell>>();
 		// create pairings of portals that can reach each other
 		let mut visible_pairs_with_cost = Vec::new();
 		for (i, source) in all_sector_portals.iter().enumerate() {
@@ -170,11 +168,11 @@ impl PortalGraph {
 		}
 		self
 	}
-	/// Create edges along the boundary of the chosen Sector [PortalNode]s to its neighbouring
-	/// sector boundary [PortalNode]s
+	/// Create edges along the boundary of the chosen Sector portal [FieldCell]s to its neighbouring
+	/// sector boundary portal [FieldCell]s
 	fn build_external_sector_edges(
 		&mut self,
-		sector_id: &(u32, u32),
+		sector_id: &SectorID,
 		map_x_dimension: u32,
 		map_z_dimension: u32,
 	) -> &mut Self {
@@ -240,7 +238,7 @@ impl PortalGraph {
 	/// # This must run after any updates to a [Portals]!
 	pub fn update_graph(
 		&mut self,
-		changed_sector: (u32, u32),
+		changed_sector: SectorID,
 		sector_portals: &SectorPortals,
 		sector_cost_fields: &SectorCostFields,
 		map_x_dimension: u32,
@@ -328,8 +326,8 @@ impl PortalGraph {
 	}
 	pub fn find_path_between_sector_portals(
 		&self,
-		source: ((u32, u32), (usize, usize)),
-		target: ((u32, u32), (usize, usize)),
+		source: (SectorID, FieldCell),
+		target: (SectorID, FieldCell),
 		sector_portals: &SectorPortals,
 	) -> Option<(i32, Vec<NodeIndex>)> {
 		if let Some(source_index) = self.find_index_from_sector_portals_and_portal_cell(
@@ -343,8 +341,8 @@ impl PortalGraph {
 				&target.1,
 			) {
 				let estimate_cost = {
-					(target.0 .0 as i32 - source.0 .0 as i32).pow(2)
-						+ (target.0 .1 as i32 - source.0 .1 as i32).pow(2)
+					(target.0.get_column() as i32 - source.0.get_column() as i32).pow(2)
+						+ (target.0.get_row() as i32 - source.0.get_row() as i32).pow(2)
 				};
 				return self.find_path_of_portals(source_index, target_index, estimate_cost);
 			}
@@ -356,7 +354,7 @@ impl PortalGraph {
 		&self,
 		portal_path: Vec<NodeIndex>,
 		sector_portals: &SectorPortals,
-	) -> Vec<((u32, u32), (usize, usize))> {
+	) -> Vec<(SectorID, FieldCell)> {
 		let mut path = Vec::new();
 		for node in portal_path.iter() {
 			let (sector_id, cell_id) = self
@@ -369,8 +367,8 @@ impl PortalGraph {
 	/// From any grid cell at a `source` sector find any pathable portals witihn that sector and generate a path from each portal to the target. Compare the results and return the path with the best cost associated with it
 	pub fn find_best_path(
 		&self,
-		source: ((u32, u32), (usize, usize)),
-		target: ((u32, u32), (usize, usize)),
+		source: (SectorID, FieldCell),
+		target: (SectorID, FieldCell),
 		sector_portals: &SectorPortals,
 		sector_cost_fields: &SectorCostFields,
 	) -> Option<(i32, Vec<NodeIndex>)> {
@@ -385,11 +383,11 @@ impl PortalGraph {
 				if cost_field
 					.can_internal_portal_pair_see_each_other(
 						source_grid_cell,
-						cell.get_column_row(),
+						*cell,
 					)
 					.0
 				{
-					source_portals.push(cell.get_column_row());
+					source_portals.push(*cell);
 				}
 			}
 		}
@@ -404,11 +402,11 @@ impl PortalGraph {
 				if cost_field
 					.can_internal_portal_pair_see_each_other(
 						target_grid_cell,
-						cell.get_column_row(),
+						*cell,
 					)
 					.0
 				{
-					target_portals.push(cell.get_column_row());
+					target_portals.push(*cell);
 				}
 			}
 		}
@@ -438,7 +436,7 @@ impl PortalGraph {
 	}
 	// /// Iterate over the "translator" (`self.node_index_translation`) and search for a portal's `search_index`
 	// /// ([NodeIndex]), if found return the `sector_id` it is located in
-	// fn find_sector_id_from_graph_index(&self, search_index: &NodeIndex) -> Option<(u32, u32)> {
+	// fn find_sector_id_from_graph_index(&self, search_index: &NodeIndex) -> Option<SectorID> {
 	// 	let translator = &self.node_index_translation;
 	// 	for (sector_id, node_ordinals) in translator.iter() {
 	// 		for nodes in node_ordinals.iter() {
@@ -458,14 +456,13 @@ impl PortalGraph {
 		&self,
 		sector_portals: &SectorPortals,
 		search_index: &NodeIndex,
-	) -> Option<((u32, u32), (usize, usize))> {
+	) -> Option<(SectorID, FieldCell)> {
 		let translator = &self.node_index_translation;
 		for (sector_id, node_ordinals) in translator.iter() {
 			for (i, nodes) in node_ordinals.iter().enumerate() {
 				for (j, n) in nodes.iter().enumerate() {
 					if *search_index == *n {
-						let cell = sector_portals.get().get(sector_id).unwrap().get()[i][j]
-							.get_column_row();
+						let cell = sector_portals.get().get(sector_id).unwrap().get()[i][j];
 						return Some((*sector_id, cell));
 					}
 				}
@@ -477,8 +474,8 @@ impl PortalGraph {
 	fn find_index_from_sector_portals_and_portal_cell(
 		&self,
 		sector_portals: &SectorPortals,
-		sector_id: &(u32, u32),
-		portal_cell: &(usize, usize),
+		sector_id: &SectorID,
+		portal_cell: &FieldCell,
 	) -> Option<NodeIndex> {
 		let translator = &self.node_index_translation;
 		// locate the indices within sector_portals which can be used to access the
@@ -492,7 +489,7 @@ impl PortalGraph {
 			.enumerate()
 		{
 			for (j, portal) in ordinals.iter().enumerate() {
-				if portal.get_column_row() == *portal_cell {
+				if *portal == *portal_cell {
 					return Some(translator.get(sector_id).unwrap()[i][j]);
 				}
 			}
@@ -503,8 +500,8 @@ impl PortalGraph {
 	// fn find_index_from_single_portal_and_portal_cell(
 	// 	&self,
 	// 	portals: &Portals,
-	// 	sector_id: &(u32, u32),
-	// 	portal_cell: &(usize, usize),
+	// 	sector_id: &SectorID,
+	// 	portal_cell: &FieldCell,
 	// ) -> Option<NodeIndex> {
 	// 	let translator = &self.node_index_translation;
 	// 	// locate the indices within sector_portals which can be used to access the
@@ -522,16 +519,16 @@ impl PortalGraph {
 
 /// Iterate through the [Portals] [Ordinal] lists to locate the graph positional indices of a particular grid portal position, these indices are then used to find the  [NodeIndex] from its recorded position in the "translator" (`self.node_index_translation`)
 fn find_index_from_single_portal_and_portal_cell(
-	translator: &BTreeMap<(u32, u32), [Vec<NodeIndex>; 4]>,
+	translator: &BTreeMap<SectorID, [Vec<NodeIndex>; 4]>,
 	portals: &Portals,
-	sector_id: &(u32, u32),
-	portal_cell: &(usize, usize),
+	sector_id: &SectorID,
+	portal_cell: &FieldCell,
 ) -> Option<NodeIndex> {
 	// locate the indices within sector_portals which can be used to access the
 	// right elements of the translator
 	for (i, ordinals) in portals.get().iter().enumerate() {
 		for (j, portal) in ordinals.iter().enumerate() {
-			if portal.get_column_row() == *portal_cell {
+			if *portal == *portal_cell {
 				return Some(translator.get(sector_id).unwrap()[i][j]);
 			}
 		}
@@ -699,9 +696,9 @@ use super::*;
 		// |_________|_________|_________|
 
 		// update the top-left CostFields and calculate new portals
-		let mutated_sector_id = (0, 0);
+		let mutated_sector_id = SectorID::new(0, 0);
 		let field = sector_cost_fields.get_mut().get_mut(&mutated_sector_id).unwrap();
-		field.set_grid_value(255, 4, 9);
+		field.set_grid_value(255, FieldCell::new(4, 9));
 		sector_portals.update_portals(mutated_sector_id, &sector_cost_fields, map_x_dimension, map_z_dimension);
 
 		// This produces a new representation with an extra portal, `x` denotes the impassable point
@@ -802,11 +799,11 @@ use super::*;
 		// |_________|_________|_________|
 
 		// form of ((sector_id), (portal_cell_id))
-		let source = ((0, 0), (4, 9));
-		let target = ((0, 2), (4, 0));
+		let source = (SectorID::new(0, 0), FieldCell::new(4, 9));
+		let target = (SectorID::new(0, 2), FieldCell::new(4, 0));
 		let portal_path = portal_graph.find_path_between_sector_portals(source, target, &sector_portals);
 		let path = portal_graph.convert_index_path_to_sector_portal_cells(portal_path.unwrap().1, &sector_portals);
-		let actual = vec![((0, 0), (4, 9)), ((0, 1), (4, 0)), ((0, 1), (4, 9)), ((0, 2), (4, 0))];
+		let actual = vec![(SectorID::new(0, 0), FieldCell::new(4, 9)), (SectorID::new(0, 1), FieldCell::new(4, 0)), (SectorID::new(0, 1), FieldCell::new(4, 9)), (SectorID::new(0, 2), FieldCell::new(4, 0))];
 		
 		assert_eq!(actual, path);
 	}

--- a/src/flowfields/portal/portals.rs
+++ b/src/flowfields/portal/portals.rs
@@ -153,9 +153,9 @@ impl Portals {
 					// walk along the side of the field
 					let mut neighbouring_pathable = Vec::new();
 					for i in column_range {
-						let field_cost = cost_field.get_grid_value(FieldCell::new(i, fixed_row));
+						let field_cost = cost_field.get_field_cell_value(FieldCell::new(i, fixed_row));
 						let adjacent_field_cost =
-							adjoining_cost_field.get_grid_value(FieldCell::new(i, FIELD_RESOLUTION - 1));
+							adjoining_cost_field.get_field_cell_value(FieldCell::new(i, FIELD_RESOLUTION - 1));
 						if field_cost != 255 && adjacent_field_cost != 255 {
 							// a pathable point along the edge so we record it to be
 							// published later as a FieldCell
@@ -200,8 +200,8 @@ impl Portals {
 					// walk along the side of the field
 					let mut neighbouring_pathable = Vec::new();
 					for j in row_range {
-						let field_cost = cost_field.get_grid_value(FieldCell::new(fixed_column, j));
-						let adjacent_field_cost = adjoining_cost_field.get_grid_value(FieldCell::new(0, j));
+						let field_cost = cost_field.get_field_cell_value(FieldCell::new(fixed_column, j));
+						let adjacent_field_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(0, j));
 						if field_cost != 255 && adjacent_field_cost != 255 {
 							// a pathable point along the edge so we record it to be
 							// published later as a FieldCell
@@ -246,8 +246,8 @@ impl Portals {
 					// walk along the side of the field
 					let mut neighbouring_pathable = Vec::new();
 					for i in column_range {
-						let field_cost = cost_field.get_grid_value(FieldCell::new(i, fixed_row));
-						let adjacent_field_cost = adjoining_cost_field.get_grid_value(FieldCell::new(i, 0));
+						let field_cost = cost_field.get_field_cell_value(FieldCell::new(i, fixed_row));
+						let adjacent_field_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(i, 0));
 						if field_cost != 255 && adjacent_field_cost != 255 {
 							// a pathable point along the edge so we record it to be
 							// published later as a FieldCell
@@ -292,9 +292,9 @@ impl Portals {
 					// walk along the side of the field
 					let mut neighbouring_pathable = Vec::new();
 					for j in row_range {
-						let field_cost = cost_field.get_grid_value(FieldCell::new(fixed_column, j));
+						let field_cost = cost_field.get_field_cell_value(FieldCell::new(fixed_column, j));
 						let adjacent_field_cost =
-							adjoining_cost_field.get_grid_value(FieldCell::new(FIELD_RESOLUTION - 1, j));
+							adjoining_cost_field.get_field_cell_value(FieldCell::new(FIELD_RESOLUTION - 1, j));
 						if field_cost != 255 && adjacent_field_cost != 255 {
 							// a pathable point along the edge so we record it to be
 							// published later as a FieldCell
@@ -337,7 +337,7 @@ impl Portals {
 			};
 		}
 	}
-	/// A [FieldCell] represents the midpoint of a segment along a boundary, for smooth pathfinding any grid cell along the segemnt should be a viable goal node when calculating an [IntegrationField]. This takes inspects the `portal_id` within the given `sector_id` and build a list of field gridc cells which comprise the true dimension of the portal
+	/// A [FieldCell] represents the midpoint of a segment along a boundary, for smooth pathfinding any field cell along the segemnt should be a viable goal node when calculating an [IntegrationField]. This takes inspects the `portal_id` within the given `sector_id` and build a list of field cells which comprise the true dimension of the portal
 	pub fn expand_portal_into_goals(
 		&self,
 		sector_cost_fields: &SectorCostFields,
@@ -348,7 +348,7 @@ impl Portals {
 		map_z_dimension: u32,
 	) -> Vec<FieldCell> {
 		// find the bounudary the portal sit along
-		let mut boundary_ordinals = get_boundary_ordinal_from_grid_cell(portal_id);
+		let mut boundary_ordinals = get_boundary_ordinal_from_field_cell(portal_id);
 		// if it's in a corner then it could apply to two boundaries, narrow it down so we know which boundary to walk
 		if boundary_ordinals.len() > 1 {
 			let valid_ordinals_for_this_sector: Vec<(Ordinal, SectorID)> =
@@ -382,9 +382,9 @@ impl Portals {
 				'left: while portal_id.get_column().checked_sub(step).is_some() {
 					let left = FieldCell::new(portal_id.get_column() - step, portal_id.get_row());
 					// check whether cell or adjoining cell is impassable
-					let left_cost = this_cost_field.get_grid_value(FieldCell::new(left.get_column(), left.get_row()));
+					let left_cost = this_cost_field.get_field_cell_value(FieldCell::new(left.get_column(), left.get_row()));
 					let neighbour_cost =
-						adjoining_cost_field.get_grid_value(FieldCell::new(left.get_column(), FIELD_RESOLUTION - 1));
+						adjoining_cost_field.get_field_cell_value(FieldCell::new(left.get_column(), FIELD_RESOLUTION - 1));
 					if left_cost != 255 && neighbour_cost != 255 {
 						goals.push(left);
 						step += 1;
@@ -398,9 +398,9 @@ impl Portals {
 				'right: while portal_id.get_column() + step < FIELD_RESOLUTION {
 					let right = FieldCell::new(portal_id.get_column() + step, portal_id.get_row());
 					// check whether cell or adjoining cell is impassable
-					let right_cost = this_cost_field.get_grid_value(right);
+					let right_cost = this_cost_field.get_field_cell_value(right);
 					let neighbour_cost =
-						adjoining_cost_field.get_grid_value(FieldCell::new(right.get_column(), FIELD_RESOLUTION - 1));
+						adjoining_cost_field.get_field_cell_value(FieldCell::new(right.get_column(), FIELD_RESOLUTION - 1));
 					if right_cost != 255 && neighbour_cost != 255 {
 						goals.push(right);
 						step += 1;
@@ -416,8 +416,8 @@ impl Portals {
 				'up: while portal_id.get_row().checked_sub(step).is_some() {
 					let up = FieldCell::new(portal_id.get_column(), portal_id.get_row() - step);
 					// check whether cell or adjoining cell is impassable
-					let up_cost = this_cost_field.get_grid_value(up);
-					let neighbour_cost = adjoining_cost_field.get_grid_value(FieldCell::new(0, up.get_row()));
+					let up_cost = this_cost_field.get_field_cell_value(up);
+					let neighbour_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(0, up.get_row()));
 					if up_cost != 255 && neighbour_cost != 255 {
 						goals.push(up);
 						step += 1;
@@ -431,8 +431,8 @@ impl Portals {
 				'down: while portal_id.get_row() + step < FIELD_RESOLUTION {
 					let down = FieldCell::new(portal_id.get_column(), portal_id.get_row() + step);
 					// check whether cell or adjoining cell is impassable
-					let right_cost = this_cost_field.get_grid_value(down);
-					let neighbour_cost = adjoining_cost_field.get_grid_value(FieldCell::new(0, down.get_row()));
+					let right_cost = this_cost_field.get_field_cell_value(down);
+					let neighbour_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(0, down.get_row()));
 					if right_cost != 255 && neighbour_cost != 255 {
 						goals.push(down);
 						step += 1;
@@ -448,8 +448,8 @@ impl Portals {
 				'left: while portal_id.get_column().checked_sub(step).is_some() {
 					let left = FieldCell::new(portal_id.get_column() - step, portal_id.get_row());
 					// check whether cell or adjoining cell is impassable
-					let left_cost = this_cost_field.get_grid_value(left);
-					let neighbour_cost = adjoining_cost_field.get_grid_value(FieldCell::new(left.get_column(), 0));
+					let left_cost = this_cost_field.get_field_cell_value(left);
+					let neighbour_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(left.get_column(), 0));
 					if left_cost != 255 && neighbour_cost != 255 {
 						goals.push(left);
 						step += 1;
@@ -463,8 +463,8 @@ impl Portals {
 				'right: while portal_id.get_column() + step < FIELD_RESOLUTION {
 					let right = FieldCell::new(portal_id.get_column() + step, portal_id.get_row());
 					// check whether cell or adjoining cell is impassable
-					let right_cost = this_cost_field.get_grid_value(right);
-					let neighbour_cost = adjoining_cost_field.get_grid_value(FieldCell::new(right.get_column(), 0));
+					let right_cost = this_cost_field.get_field_cell_value(right);
+					let neighbour_cost = adjoining_cost_field.get_field_cell_value(FieldCell::new(right.get_column(), 0));
 					if right_cost != 255 && neighbour_cost != 255 {
 						goals.push(right);
 						step += 1;
@@ -480,9 +480,9 @@ impl Portals {
 				'up: while portal_id.get_row().checked_sub(step).is_some() {
 					let up = FieldCell::new(portal_id.get_column(), portal_id.get_row() - step);
 					// check whether cell or adjoining cell is impassable
-					let up_cost = this_cost_field.get_grid_value(up);
+					let up_cost = this_cost_field.get_field_cell_value(up);
 					let neighbour_cost =
-						adjoining_cost_field.get_grid_value(FieldCell::new(FIELD_RESOLUTION - 1, up.get_row()));
+						adjoining_cost_field.get_field_cell_value(FieldCell::new(FIELD_RESOLUTION - 1, up.get_row()));
 					if up_cost != 255 && neighbour_cost != 255 {
 						goals.push(up);
 						step += 1;
@@ -496,9 +496,9 @@ impl Portals {
 				'down: while portal_id.get_row() + step < FIELD_RESOLUTION {
 					let down = FieldCell::new(portal_id.get_column(), portal_id.get_row() + step);
 					// check whether cell or adjoining cell is impassable
-					let right_cost = this_cost_field.get_grid_value(down);
+					let right_cost = this_cost_field.get_field_cell_value(down);
 					let neighbour_cost =
-						adjoining_cost_field.get_grid_value(FieldCell::new(FIELD_RESOLUTION - 1, down.get_row()));
+						adjoining_cost_field.get_field_cell_value(FieldCell::new(FIELD_RESOLUTION - 1, down.get_row()));
 					if right_cost != 255 && neighbour_cost != 255 {
 						goals.push(down);
 						step += 1;
@@ -529,8 +529,8 @@ use super::*;
 		let sector_id = SectorID::new(0, 0);
 		let cost_field = sector_cost_fields.get_mut().get_mut(&sector_id).unwrap();
 		// switch some fields to impassable
-		cost_field.set_grid_value(255, FieldCell::new(9, 5));
-		cost_field.set_grid_value(255, FieldCell::new(0, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(9, 5));
+		cost_field.set_field_cell_value(255, FieldCell::new(0, 9));
 		let mut portals = Portals::default();
 		portals.recalculate_portals(&sector_cost_fields, &sector_id, 30, 30);
 		let northern_side_portal_count = 0;
@@ -548,8 +548,8 @@ use super::*;
 		let sector_id = SectorID::new(1, 0);
 		let cost_field = sector_cost_fields.get_mut().get_mut(&sector_id).unwrap();
 		// switch some fields to impassable
-		cost_field.set_grid_value(255, FieldCell::new(9, 5));
-		cost_field.set_grid_value(255, FieldCell::new(0, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(9, 5));
+		cost_field.set_field_cell_value(255, FieldCell::new(0, 9));
 		let mut portals = Portals::default();
 		portals.recalculate_portals(&sector_cost_fields, &sector_id, 30, 30);
 		let northern_side_portal_count = 0;
@@ -567,8 +567,8 @@ use super::*;
 		let sector_id = SectorID::new(1, 1);
 		let cost_field = sector_cost_fields.get_mut().get_mut(&sector_id).unwrap();
 		// switch some fields to impassable
-		cost_field.set_grid_value(255, FieldCell::new(9, 5));
-		cost_field.set_grid_value(255, FieldCell::new(0, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(9, 5));
+		cost_field.set_field_cell_value(255, FieldCell::new(0, 9));
 		let mut portals = Portals::default();
 		portals.recalculate_portals(&sector_cost_fields, &sector_id, 30, 30);
 		let northern_side_portal_count = 1;
@@ -586,10 +586,10 @@ use super::*;
 		let sector_id = SectorID::new(1, 2);
 		let cost_field = sector_cost_fields.get_mut().get_mut(&sector_id).unwrap();
 		// switch some fields to impassable
-		cost_field.set_grid_value(255, FieldCell::new(4, 0));
-		cost_field.set_grid_value(255, FieldCell::new(6, 0));
-		cost_field.set_grid_value(255, FieldCell::new(9, 5));
-		cost_field.set_grid_value(255, FieldCell::new(0, 9));
+		cost_field.set_field_cell_value(255, FieldCell::new(4, 0));
+		cost_field.set_field_cell_value(255, FieldCell::new(6, 0));
+		cost_field.set_field_cell_value(255, FieldCell::new(9, 5));
+		cost_field.set_field_cell_value(255, FieldCell::new(0, 9));
 		let mut portals = Portals::default();
 		portals.recalculate_portals(&sector_cost_fields, &sector_id, 30, 30);
 		let northern_side_portal_count = 3;
@@ -636,7 +636,7 @@ use super::*;
 		// update the top-left CostFields and calculate new portals
 		let mutated_sector_id = SectorID::new(0, 0);
 		let field = sector_cost_fields.get_mut().get_mut(&mutated_sector_id).unwrap();
-		field.set_grid_value(255, FieldCell::new(4, 9));
+		field.set_field_cell_value(255, FieldCell::new(4, 9));
 		sector_portals.update_portals(mutated_sector_id, &sector_cost_fields, map_x_dimension, map_z_dimension);
 
 		let post_first = sector_portals.get_mut().get_mut(&mutated_sector_id).unwrap().clone();
@@ -765,7 +765,7 @@ use super::*;
 		let map_x_dimension = 30;
 		let map_z_dimension = 30;
 		let mut sector_cost_fields = SectorCostFields::new(map_x_dimension, map_z_dimension);
-		sector_cost_fields.get_mut().get_mut(&sector_id).unwrap().set_grid_value(255, FieldCell::new(3, 0));
+		sector_cost_fields.get_mut().get_mut(&sector_id).unwrap().set_field_cell_value(255, FieldCell::new(3, 0));
 
 		let mut sector_portals = SectorPortals::new(map_x_dimension, map_z_dimension);
 		// build portals
@@ -788,7 +788,7 @@ use super::*;
 		let map_x_dimension = 30;
 		let map_z_dimension = 30;
 		let mut sector_cost_fields = SectorCostFields::new(map_x_dimension, map_z_dimension);
-		sector_cost_fields.get_mut().get_mut(&neighbour_sector_id).unwrap().set_grid_value(255, FieldCell::new(3, 9));
+		sector_cost_fields.get_mut().get_mut(&neighbour_sector_id).unwrap().set_field_cell_value(255, FieldCell::new(3, 9));
 
 		let mut sector_portals = SectorPortals::new(map_x_dimension, map_z_dimension);
 		// build portals

--- a/src/flowfields/sectors.rs
+++ b/src/flowfields/sectors.rs
@@ -121,7 +121,7 @@ impl SectorCostFields {
 			for (row, record) in rdr.records().enumerate() {
 				for (column, value) in record.unwrap().iter().enumerate() {
 					let value_u8: u8 = value.parse().expect("CSV expects u8 values");
-					cost_field.set_grid_value(value_u8, FieldCell::new(column, row));
+					cost_field.set_field_cell_value(value_u8, FieldCell::new(column, row));
 				}
 			}
 			sector_cost_fields.get_mut().insert(*sector_id, cost_field);
@@ -319,7 +319,7 @@ pub fn get_ordinal_and_ids_of_neighbouring_sectors(
 }
 
 /// From the position of a `cell_id`, if it sits along a boundary, return the [Ordinal] of that boundary. Note that if the `cell_id` is in a field corner then it'll have two boundaries. Note that if the `cell_id` is not in fact along a boundary then this will panic
-pub fn get_boundary_ordinal_from_grid_cell(cell_id: &FieldCell) -> Vec<Ordinal> {
+pub fn get_boundary_ordinal_from_field_cell(cell_id: &FieldCell) -> Vec<Ordinal> {
 	let mut boundaries = Vec::new();
 	if cell_id.get_row() == 0 {
 		boundaries.push(Ordinal::North);

--- a/src/flowfields/utilities.rs
+++ b/src/flowfields/utilities.rs
@@ -1,6 +1,7 @@
 //! Useful structures and tools used by the fields
 //!
 
+use crate::prelude::*;
 use bevy::prelude::*;
 
 /// Determines the number of Sectors by dividing the map length and depth by this value
@@ -27,117 +28,141 @@ pub enum Ordinal {
 
 impl Ordinal {
 	/// Based on a grid cells `(column, row)` position find its neighbours based on FIELD_RESOLUTION limits (up to 4)
-	pub fn get_orthogonal_cell_neighbours(cell_id: (usize, usize)) -> Vec<(usize, usize)> {
+	pub fn get_orthogonal_cell_neighbours(cell_id: FieldCell) -> Vec<FieldCell> {
 		let mut neighbours = Vec::new();
-		if cell_id.1 > 0 {
-			neighbours.push((cell_id.0, cell_id.1 - 1)); // northern cell coords
+		if cell_id.get_row() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column(), cell_id.get_row() - 1)); // northern cell coords
 		}
-		if cell_id.0 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0 + 1, cell_id.1)); // eastern cell coords
+		if cell_id.get_column() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column() + 1, cell_id.get_row())); // eastern cell coords
 		}
-		if cell_id.1 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0, cell_id.1 + 1)); // southern cell coords
+		if cell_id.get_row() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column(), cell_id.get_row() + 1)); // southern cell coords
 		}
-		if cell_id.0 > 0 {
-			neighbours.push((cell_id.0 - 1, cell_id.1)); // western cell coords
+		if cell_id.get_column() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column() - 1, cell_id.get_row())); // western cell coords
 		}
 		neighbours
 	}
 	/// Based on a grid cells `(column, row)` position find all possible neighbours inclduing diagonal directions
-	pub fn get_all_cell_neighbours(cell_id: (usize, usize)) -> Vec<(usize, usize)> {
+	pub fn get_all_cell_neighbours(cell_id: FieldCell) -> Vec<FieldCell> {
 		let mut neighbours = Vec::new();
-		if cell_id.1 > 0 {
-			neighbours.push((cell_id.0, cell_id.1 - 1)); // northern cell coords
+		if cell_id.get_row() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column(), cell_id.get_row() - 1)); // northern cell coords
 		}
-		if cell_id.0 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0 + 1, cell_id.1)); // eastern cell coords
+		if cell_id.get_column() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column() + 1, cell_id.get_row())); // eastern cell coords
 		}
-		if cell_id.1 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0, cell_id.1 + 1)); // southern cell coords
+		if cell_id.get_row() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column(), cell_id.get_row() + 1)); // southern cell coords
 		}
-		if cell_id.0 > 0 {
-			neighbours.push((cell_id.0 - 1, cell_id.1)); // western cell coords
+		if cell_id.get_column() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column() - 1, cell_id.get_row())); // western cell coords
 		}
-		if cell_id.1 > 0 && cell_id.0 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0 + 1, cell_id.1 - 1)); // north-east cell
+		if cell_id.get_row() > 0 && cell_id.get_column() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column() + 1, cell_id.get_row() - 1)); // north-east cell
 		}
-		if cell_id.1 < FIELD_RESOLUTION - 1 && cell_id.0 < FIELD_RESOLUTION - 1 {
-			neighbours.push((cell_id.0 + 1, cell_id.1 + 1)); // south-east cell
+		if cell_id.get_row() < FIELD_RESOLUTION - 1 && cell_id.get_column() < FIELD_RESOLUTION - 1 {
+			neighbours.push(FieldCell::new(cell_id.get_column() + 1, cell_id.get_row() + 1)); // south-east cell
 		}
-		if cell_id.1 < FIELD_RESOLUTION - 1 && cell_id.0 > 0 {
-			neighbours.push((cell_id.0 - 1, cell_id.1 + 1)); // south-west cell
+		if cell_id.get_row() < FIELD_RESOLUTION - 1 && cell_id.get_column() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column() - 1, cell_id.get_row() + 1)); // south-west cell
 		}
-		if cell_id.1 > 0 && cell_id.0 > 0 {
-			neighbours.push((cell_id.0 - 1, cell_id.1 - 1)); // north-west cell
+		if cell_id.get_row() > 0 && cell_id.get_column() > 0 {
+			neighbours.push(FieldCell::new(cell_id.get_column() - 1, cell_id.get_row() - 1)); // north-west cell
 		}
 		neighbours
 	}
 	/// Based on a sectors `(column, row)` position find its neighbours based on map size limits (up to 4)
 	pub fn get_sector_neighbours(
-		sector_id: &(u32, u32),
+		sector_id: &SectorID,
 		map_x_dimension: u32,
 		map_z_dimension: u32,
-	) -> Vec<(u32, u32)> {
+	) -> Vec<SectorID> {
 		let mut neighbours = Vec::new();
 		let sector_x_column_limit = map_x_dimension / SECTOR_RESOLUTION as u32 - 1;
 		let sector_z_row_limit = map_z_dimension / SECTOR_RESOLUTION as u32 - 1;
-		if sector_id.1 > 0 {
-			neighbours.push((sector_id.0, sector_id.1 - 1)); // northern sector coords
+		if sector_id.get_row() > 0 {
+			neighbours.push(SectorID::new(
+				sector_id.get_column(),
+				sector_id.get_row() - 1,
+			)); // northern sector coords
 		}
-		if sector_id.0 < sector_x_column_limit {
-			neighbours.push((sector_id.0 + 1, sector_id.1)); // eastern sector coords
+		if sector_id.get_column() < sector_x_column_limit {
+			neighbours.push(SectorID::new(
+				sector_id.get_column() + 1,
+				sector_id.get_row(),
+			)); // eastern sector coords
 		}
-		if sector_id.1 < sector_z_row_limit {
-			neighbours.push((sector_id.0, sector_id.1 + 1)); // southern sector coords
+		if sector_id.get_row() < sector_z_row_limit {
+			neighbours.push(SectorID::new(
+				sector_id.get_column(),
+				sector_id.get_row() + 1,
+			)); // southern sector coords
 		}
-		if sector_id.0 > 0 {
-			neighbours.push((sector_id.0 - 1, sector_id.1)); // western sector coords
+		if sector_id.get_column() > 0 {
+			neighbours.push(SectorID::new(
+				sector_id.get_column() - 1,
+				sector_id.get_row(),
+			)); // western sector coords
 		}
 		neighbours
 	}
 	/// Based on a sectors `(column, row)` position find the [Ordinal] directions for its boundaries that can support [crate::prelude::Portals]
 	pub fn get_sector_portal_ordinals(
-		sector_id: &(u32, u32),
+		sector_id: &SectorID,
 		map_x_dimension: u32,
 		map_z_dimension: u32,
 	) -> Vec<Ordinal> {
 		let mut neighbours = Vec::new();
 		let sector_x_column_limit = map_x_dimension / SECTOR_RESOLUTION as u32 - 1;
 		let sector_z_row_limit = map_z_dimension / SECTOR_RESOLUTION as u32 - 1;
-		if sector_id.1 > 0 {
+		if sector_id.get_row() > 0 {
 			neighbours.push(Ordinal::North); // northern sector coords
 		}
-		if sector_id.0 < sector_x_column_limit {
+		if sector_id.get_column() < sector_x_column_limit {
 			neighbours.push(Ordinal::East); // eastern sector coords
 		}
-		if sector_id.1 < sector_z_row_limit {
+		if sector_id.get_row() < sector_z_row_limit {
 			neighbours.push(Ordinal::South); // southern sector coords
 		}
-		if sector_id.0 > 0 {
+		if sector_id.get_column() > 0 {
 			neighbours.push(Ordinal::West); // western sector coords
 		}
 		neighbours
 	}
 	/// Based on a sectors `(column, row)` position find its neighbours based on map size limits (up to 4) and include the [Ordinal] direction in the result
 	pub fn get_sector_neighbours_with_ordinal(
-		sector_id: &(u32, u32),
+		sector_id: &SectorID,
 		map_x_dimension: u32,
 		map_z_dimension: u32,
-	) -> Vec<(Ordinal, (u32, u32))> {
+	) -> Vec<(Ordinal, SectorID)> {
 		let mut neighbours = Vec::new();
 		let sector_x_column_limit = map_x_dimension / SECTOR_RESOLUTION as u32 - 1;
 		let sector_z_row_limit = map_z_dimension / SECTOR_RESOLUTION as u32 - 1;
-		if sector_id.1 > 0 {
-			neighbours.push((Ordinal::North, (sector_id.0, sector_id.1 - 1))); // northern sector coords
+		if sector_id.get_row() > 0 {
+			neighbours.push((
+				Ordinal::North,
+				SectorID::new(sector_id.get_column(), sector_id.get_row() - 1),
+			)); // northern sector coords
 		}
-		if sector_id.0 < sector_x_column_limit {
-			neighbours.push((Ordinal::East, (sector_id.0 + 1, sector_id.1))); // eastern sector coords
+		if sector_id.get_column() < sector_x_column_limit {
+			neighbours.push((
+				Ordinal::East,
+				SectorID::new(sector_id.get_column() + 1, sector_id.get_row()),
+			)); // eastern sector coords
 		}
-		if sector_id.1 < sector_z_row_limit {
-			neighbours.push((Ordinal::South, (sector_id.0, sector_id.1 + 1))); // southern sector coords
+		if sector_id.get_row() < sector_z_row_limit {
+			neighbours.push((
+				Ordinal::South,
+				SectorID::new(sector_id.get_column(), sector_id.get_row() + 1),
+			)); // southern sector coords
 		}
-		if sector_id.0 > 0 {
-			neighbours.push((Ordinal::West, (sector_id.0 - 1, sector_id.1))); // western sector coords
+		if sector_id.get_column() > 0 {
+			neighbours.push((
+				Ordinal::West,
+				SectorID::new(sector_id.get_column() - 1, sector_id.get_row()),
+			)); // western sector coords
 		}
 		neighbours
 	}
@@ -156,9 +181,9 @@ impl Ordinal {
 		}
 	}
 	/// For two cells next to each other it can be useful to find the [Ordinal] point from the `source` to the `target`
-	pub fn cell_to_cell_direction(target: (usize, usize), source: (usize, usize)) -> Self {
-		let i32_target = (target.0 as i32, target.1 as i32);
-		let i32_source = (source.0 as i32, source.1 as i32);
+	pub fn cell_to_cell_direction(target: FieldCell, source: FieldCell) -> Self {
+		let i32_target = (target.get_column() as i32, target.get_row() as i32);
+		let i32_source = (source.get_column() as i32, source.get_row() as i32);
 
 		let direction = (i32_target.0 - i32_source.0, i32_target.1 - i32_source.1);
 		match direction {
@@ -177,9 +202,9 @@ impl Ordinal {
 		}
 	}
 	/// For two sectors next to each other it can be useful to find the [Ordinal] from the `source` to the `target`. This will panic if the two sectors are not orthogonally adjacent
-	pub fn sector_to_sector_direction(target: (u32, u32), source: (u32, u32)) -> Option<Self> {
-		let i32_target = (target.0 as i32, target.1 as i32);
-		let i32_source = (source.0 as i32, source.1 as i32);
+	pub fn sector_to_sector_direction(target: SectorID, source: SectorID) -> Option<Self> {
+		let i32_target = (target.get_column() as i32, target.get_row() as i32);
+		let i32_source = (source.get_column() as i32, source.get_row() as i32);
 
 		let direction = (i32_target.0 - i32_source.0, i32_target.1 - i32_source.1);
 		match direction {
@@ -204,71 +229,80 @@ mod tests {
 	use super::*;
 	#[test]
 	fn ordinal_grid_cell_neighbours() {
-		let cell_id = (0, 0);
+		let cell_id = FieldCell::new(0, 0);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
-		let actual = vec![(1, 0), (0, 1)];
+		let actual = vec![FieldCell::new(1, 0), FieldCell::new(0, 1)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_grid_cell_neighbours2() {
-		let cell_id = (9, 9);
+		let cell_id = FieldCell::new(9, 9);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
-		let actual = vec![(9, 8), (8, 9)];
+		let actual = vec![FieldCell::new(9, 8), FieldCell::new(8, 9)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_grid_cell_neighbours3() {
-		let cell_id = (4, 4);
+		let cell_id = FieldCell::new(4, 4);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
-		let actual = vec![(4, 3), (5, 4), (4, 5), (3, 4)];
+		let actual = vec![FieldCell::new(4, 3), FieldCell::new(5, 4), FieldCell::new(4, 5), FieldCell::new(3, 4)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_grid_cell_neighbours4() {
-		let cell_id = (5, 0);
+		let cell_id = FieldCell::new(5, 0);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
-		let actual = vec![(6, 0), (5, 1), (4, 0)];
+		let actual = vec![FieldCell::new(6, 0), FieldCell::new(5, 1), FieldCell::new(4, 0)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_sector_neighbours() {
-		let sector_id = (0, 0);
+		let sector_id = SectorID::new(0, 0);
 		let map_x_dimension = 300;
 		let map_z_dimension = 550;
 		let result = Ordinal::get_sector_neighbours(&sector_id, map_x_dimension, map_z_dimension);
-		let actual = vec![(1, 0), (0, 1)];
+		let actual = vec![SectorID::new(1, 0), SectorID::new(0, 1)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_sector_neighbours2() {
-		let sector_id = (29, 54);
+		let sector_id = SectorID::new(29, 54);
 		let map_x_dimension = 300;
 		let map_z_dimension = 550;
 		let result = Ordinal::get_sector_neighbours(&sector_id, map_x_dimension, map_z_dimension);
-		let actual = vec![(29, 53), (28, 54)];
+		let actual = vec![SectorID::new(29, 53), SectorID::new(28, 54)];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_sector_neighbours3() {
-		let sector_id = (14, 31);
+		let sector_id = SectorID::new(14, 31);
 		let map_x_dimension = 300;
 		let map_z_dimension = 550;
 		let result = Ordinal::get_sector_neighbours(&sector_id, map_x_dimension, map_z_dimension);
-		let actual = vec![(14, 30), (15, 31), (14, 32), (13, 31)];
+		let actual = vec![
+			SectorID::new(14, 30),
+			SectorID::new(15, 31),
+			SectorID::new(14, 32),
+			SectorID::new(13, 31),
+		];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn ordinal_sector_neighbours4() {
-		let sector_id = (0, 13);
+		let sector_id = SectorID::new(0, 13);
 		let map_x_dimension = 300;
 		let map_z_dimension = 550;
 		let result = Ordinal::get_sector_neighbours(&sector_id, map_x_dimension, map_z_dimension);
-		let actual = vec![(0, 12), (1, 13), (0, 14)];
+		let actual = vec![
+			SectorID::new(0, 12),
+			SectorID::new(1, 13),
+			SectorID::new(0, 14),
+		];
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn get_northern_oridnals() {
-		let sector_id = (3, 0);
+		let sector_id = SectorID::new(3, 0);
 		let map_x_dimension = 200;
 		let map_z_dimension = 200;
 		let result =
@@ -278,7 +312,7 @@ mod tests {
 	}
 	#[test]
 	fn get_eastern_oridnals() {
-		let sector_id = (19, 5);
+		let sector_id = SectorID::new(19, 5);
 		let map_x_dimension = 200;
 		let map_z_dimension = 200;
 		let result =
@@ -288,7 +322,7 @@ mod tests {
 	}
 	#[test]
 	fn get_southern_oridnals() {
-		let sector_id = (4, 19);
+		let sector_id = SectorID::new(4, 19);
 		let map_x_dimension = 200;
 		let map_z_dimension = 200;
 		let result =
@@ -298,7 +332,7 @@ mod tests {
 	}
 	#[test]
 	fn get_western_oridnals() {
-		let sector_id = (0, 5);
+		let sector_id = SectorID::new(0, 5);
 		let map_x_dimension = 200;
 		let map_z_dimension = 200;
 		let result =
@@ -308,7 +342,7 @@ mod tests {
 	}
 	#[test]
 	fn get_centre_oridnals() {
-		let sector_id = (4, 5);
+		let sector_id = SectorID::new(4, 5);
 		let map_x_dimension = 200;
 		let map_z_dimension = 200;
 		let result =
@@ -318,64 +352,64 @@ mod tests {
 	}
 	#[test]
 	fn cell_to_cell_north() {
-		let target = (6, 2);
-		let source = (6, 3);
+		let target = FieldCell::new(6, 2);
+		let source = FieldCell::new(6, 3);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::North;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_north_east() {
-		let target = (7, 2);
-		let source = (6, 3);
+		let target = FieldCell::new(7, 2);
+		let source = FieldCell::new(6, 3);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::NorthEast;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_east() {
-		let target = (6, 7);
-		let source = (5, 7);
+		let target = FieldCell::new(6, 7);
+		let source = FieldCell::new(5, 7);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::East;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_south_east() {
-		let target = (5, 5);
-		let source = (4, 4);
+		let target = FieldCell::new(5, 5);
+		let source = FieldCell::new(4, 4);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::SouthEast;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_south() {
-		let target = (3, 1);
-		let source = (3, 0);
+		let target = FieldCell::new(3, 1);
+		let source = FieldCell::new(3, 0);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::South;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_south_west() {
-		let target = (6, 9);
-		let source = (7, 8);
+		let target = FieldCell::new(6, 9);
+		let source = FieldCell::new(7, 8);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::SouthWest;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_west() {
-		let target = (5, 7);
-		let source = (6, 7);
+		let target = FieldCell::new(5, 7);
+		let source = FieldCell::new(6, 7);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::West;
 		assert_eq!(actual, result);
 	}
 	#[test]
 	fn cell_to_cell_north_west() {
-		let target = (0, 0);
-		let source = (1, 1);
+		let target = FieldCell::new(0, 0);
+		let source = FieldCell::new(1, 1);
 		let result = Ordinal::cell_to_cell_direction(target, source);
 		let actual = Ordinal::NorthWest;
 		assert_eq!(actual, result);

--- a/src/flowfields/utilities.rs
+++ b/src/flowfields/utilities.rs
@@ -9,7 +9,7 @@ pub const SECTOR_RESOLUTION: usize = 10;
 /// Defines the dimenions of all field arrays
 pub const FIELD_RESOLUTION: usize = 10;
 
-/// Convenience way of accessing the 4 sides of a sector in [crate::prelude::Portals], the 4 sides of a grid cell in [crate::prelude::IntegrationField] and the 8 directions
+/// Convenience way of accessing the 4 sides of a sector in [crate::prelude::Portals], the 4 sides of a field cell in [crate::prelude::IntegrationField] and the 8 directions
 /// of movement in [crate::prelude::flow_field::FlowField]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -27,7 +27,7 @@ pub enum Ordinal {
 }
 
 impl Ordinal {
-	/// Based on a grid cells `(column, row)` position find its neighbours based on FIELD_RESOLUTION limits (up to 4)
+	/// Based on a field cells `(column, row)` position find its neighbours based on FIELD_RESOLUTION limits (up to 4)
 	pub fn get_orthogonal_cell_neighbours(cell_id: FieldCell) -> Vec<FieldCell> {
 		let mut neighbours = Vec::new();
 		if cell_id.get_row() > 0 {
@@ -44,7 +44,7 @@ impl Ordinal {
 		}
 		neighbours
 	}
-	/// Based on a grid cells `(column, row)` position find all possible neighbours inclduing diagonal directions
+	/// Based on a field cells `(column, row)` position find all possible neighbours inclduing diagonal directions
 	pub fn get_all_cell_neighbours(cell_id: FieldCell) -> Vec<FieldCell> {
 		let mut neighbours = Vec::new();
 		if cell_id.get_row() > 0 {
@@ -228,28 +228,28 @@ impl Ordinal {
 mod tests {
 	use super::*;
 	#[test]
-	fn ordinal_grid_cell_neighbours() {
+	fn ordinal_field_cell_neighbours() {
 		let cell_id = FieldCell::new(0, 0);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
 		let actual = vec![FieldCell::new(1, 0), FieldCell::new(0, 1)];
 		assert_eq!(actual, result);
 	}
 	#[test]
-	fn ordinal_grid_cell_neighbours2() {
+	fn ordinal_field_cell_neighbours2() {
 		let cell_id = FieldCell::new(9, 9);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
 		let actual = vec![FieldCell::new(9, 8), FieldCell::new(8, 9)];
 		assert_eq!(actual, result);
 	}
 	#[test]
-	fn ordinal_grid_cell_neighbours3() {
+	fn ordinal_field_cell_neighbours3() {
 		let cell_id = FieldCell::new(4, 4);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
 		let actual = vec![FieldCell::new(4, 3), FieldCell::new(5, 4), FieldCell::new(4, 5), FieldCell::new(3, 4)];
 		assert_eq!(actual, result);
 	}
 	#[test]
-	fn ordinal_grid_cell_neighbours4() {
+	fn ordinal_field_cell_neighbours4() {
 		let cell_id = FieldCell::new(5, 0);
 		let result = Ordinal::get_orthogonal_cell_neighbours(cell_id);
 		let actual = vec![FieldCell::new(6, 0), FieldCell::new(5, 1), FieldCell::new(4, 0)];

--- a/src/plugin/cost_layer.rs
+++ b/src/plugin/cost_layer.rs
@@ -9,10 +9,10 @@ use bevy::prelude::*;
 /// Used to update a sectors [CostField]
 #[derive(Event)]
 pub struct EventUpdateCostfieldsCell {
-	/// Field/grid cell to update
-	cell: (usize, usize),
+	/// FieldCell to update
+	cell: FieldCell,
 	/// The sector the field/grid cell resides in
-	sector: (u32, u32),
+	sector: SectorID,
 	/// The value the field/grid cell should be assigned
 	cell_value: u8,
 }
@@ -20,7 +20,7 @@ pub struct EventUpdateCostfieldsCell {
 impl EventUpdateCostfieldsCell {
 	/// Create a new instance of [EventUpdateCostfieldsCell]
 	#[cfg(not(tarpaulin_include))]
-	pub fn new(cell: (usize, usize), sector: (u32, u32), cell_value: u8) -> Self {
+	pub fn new(cell: FieldCell, sector: SectorID, cell_value: u8) -> Self {
 		EventUpdateCostfieldsCell {
 			cell,
 			sector,
@@ -28,11 +28,11 @@ impl EventUpdateCostfieldsCell {
 		}
 	}
 	#[cfg(not(tarpaulin_include))]
-	pub fn get_cell(&self) -> (usize, usize) {
+	pub fn get_cell(&self) -> FieldCell {
 		self.cell
 	}
 	#[cfg(not(tarpaulin_include))]
-	pub fn get_sector(&self) -> (u32, u32) {
+	pub fn get_sector(&self) -> SectorID {
 		self.sector
 	}
 	#[cfg(not(tarpaulin_include))]
@@ -54,7 +54,7 @@ pub fn process_costfields_updates(
 		for mut costfields in costfields_q.iter_mut() {
 			for (sector, field) in costfields.get_mut().iter_mut() {
 				if *sector == sector_id {
-					field.set_grid_value(cost, grid_cell.0, grid_cell.1);
+					field.set_grid_value(cost, grid_cell);
 					event_portal_rebuild.send(EventRebuildSectorPortals::new(sector_id));
 				}
 			}
@@ -66,16 +66,16 @@ pub fn process_costfields_updates(
 #[derive(Event)]
 pub struct EventRebuildSectorPortals {
 	/// Unique ID of the sector
-	sector_id: (u32, u32),
+	sector_id: SectorID,
 }
 
 impl EventRebuildSectorPortals {
 	#[cfg(not(tarpaulin_include))]
-	pub fn new(sector_id: (u32, u32)) -> Self {
+	pub fn new(sector_id: SectorID) -> Self {
 		EventRebuildSectorPortals { sector_id }
 	}
 	#[cfg(not(tarpaulin_include))]
-	pub fn get_sector_id(&self) -> (u32, u32) {
+	pub fn get_sector_id(&self) -> SectorID {
 		self.sector_id
 	}
 }
@@ -109,14 +109,14 @@ pub fn rebuild_portals(
 #[derive(Event)]
 pub struct EventUpdatePortalGraph {
 	/// Unique ID of the sector
-	sector_id: (u32, u32),
+	sector_id: SectorID,
 }
 
 impl EventUpdatePortalGraph {
-	pub fn new(sector_id: (u32, u32)) -> Self {
+	pub fn new(sector_id: SectorID) -> Self {
 		EventUpdatePortalGraph { sector_id }
 	}
-	pub fn get_sector_id(&self) -> (u32, u32) {
+	pub fn get_sector_id(&self) -> SectorID {
 		self.sector_id
 	}
 }
@@ -152,7 +152,7 @@ pub fn update_portal_graph(
 }
 /// For the given sector any route or [FlowField] making use of it needs to have the cached entry removed and a new request made to regenerate the route
 #[derive(Event)]
-pub struct EventCleanCaches((u32, u32));
+pub struct EventCleanCaches(SectorID);
 
 //TODO in order to regenerate the routes the source field cell needs to be known - a cost field change may make that field cell invalid though... disable regen for now, steering pipeline/character controler will have to poll the route cache and request a new one....
 /// Lookup any cached data records making use of sectors that have had their [CostField] adjusted and remove them from the cache

--- a/src/plugin/cost_layer.rs
+++ b/src/plugin/cost_layer.rs
@@ -11,9 +11,9 @@ use bevy::prelude::*;
 pub struct EventUpdateCostfieldsCell {
 	/// FieldCell to update
 	cell: FieldCell,
-	/// The sector the field/grid cell resides in
+	/// The sector the field cell resides in
 	sector: SectorID,
-	/// The value the field/grid cell should be assigned
+	/// The value the field cell should be assigned
 	cell_value: u8,
 }
 
@@ -48,13 +48,13 @@ pub fn process_costfields_updates(
 	mut event_portal_rebuild: EventWriter<EventRebuildSectorPortals>,
 ) {
 	for event in events.iter() {
-		let grid_cell = event.get_cell();
+		let field_cell = event.get_cell();
 		let sector_id = event.get_sector();
 		let cost = event.get_cost_value();
 		for mut costfields in costfields_q.iter_mut() {
 			for (sector, field) in costfields.get_mut().iter_mut() {
 				if *sector == sector_id {
-					field.set_grid_value(cost, grid_cell);
+					field.set_field_cell_value(cost, field_cell);
 					event_portal_rebuild.send(EventRebuildSectorPortals::new(sector_id));
 				}
 			}
@@ -209,7 +209,7 @@ pub fn clean_cache(
 		}
 		// // send events to regenerate routes
 		// for metadata in to_purge.iter() {
-		// 	//TODO someway of getting the orignal source_grid_cell instead of (5,5) assumption
+		// 	//TODO someway of getting the orignal source_field_cell instead of (5,5) assumption
 		// 	event_path_request.send(EventPathRequest::new(
 		// 		metadata.get_source_sector(),
 		// 		(5, 5),

--- a/src/plugin/flow_layer.rs
+++ b/src/plugin/flow_layer.rs
@@ -9,21 +9,21 @@ use bevy::prelude::*;
 #[derive(Event)]
 pub struct EventPathRequest {
 	/// The starting sector of the request
-	source_sector: (u32, u32),
+	source_sector: SectorID,
 	/// The starting field/grid cell of the starting sector
-	source_field_cell: (usize, usize),
+	source_field_cell: FieldCell,
 	/// The sector to try and find a path to
-	target_sector: (u32, u32),
+	target_sector: SectorID,
 	/// The field/grid cell in the target sector to find a path to
-	target_goal: (usize, usize),
+	target_goal: FieldCell,
 }
 
 impl EventPathRequest {
 	pub fn new(
-		source_sector: (u32, u32),
-		source_field_cell: (usize, usize),
-		target_sector: (u32, u32),
-		target_goal: (usize, usize),
+		source_sector: SectorID,
+		source_field_cell: FieldCell,
+		target_sector: SectorID,
+		target_goal: FieldCell,
 	) -> Self {
 		EventPathRequest {
 			source_sector,
@@ -96,7 +96,7 @@ pub fn handle_path_requests(
 /// about the elements which an actor would use to exit the sector so we filter
 /// the route and trim it down
 #[allow(clippy::type_complexity)]
-pub fn filter_path(path: &mut Vec<((u32, u32), (usize, usize))>, target_goal: (usize, usize)) {
+pub fn filter_path(path: &mut Vec<(SectorID, FieldCell)>, target_goal: FieldCell) {
 	let mut path_based_on_portal_exits = Vec::new();
 	// target sector and entry portal where we switch the entry portal cell to the goal
 	let mut end = path.pop().unwrap();
@@ -236,25 +236,25 @@ mod tests {
 	#[test]
 	fn filter_graph_route() {
 		// path in 3x3 sector grid, moving from top right to bottom left
-		let mut path: Vec<((u32, u32), (usize, usize))> = vec![
-			((2, 0), (0, 4)), // start sector and exit
-			((1, 0), (9, 4)), // entry portal of next sector
-			((1, 0), (3, 9)), // exit portal of next sector
-			((1, 1), (3, 0)), // entry portal of next sector
-			((1, 1), (5, 9)), // exit portal of next sector
-			((1, 2), (5, 0)), // entry portal of next sector
-			((1, 2), (0, 3)), // exit portal of next sector
-			((0, 2), (9, 3)) // goal sector and entry portal
+		let mut path: Vec<(SectorID, FieldCell)> = vec![
+			(SectorID::new(2, 0), FieldCell::new(0, 4)), // start sector and exit
+			(SectorID::new(1, 0), FieldCell::new(9, 4)), // entry portal of next sector
+			(SectorID::new(1, 0), FieldCell::new(3, 9)), // exit portal of next sector
+			(SectorID::new(1, 1), FieldCell::new(3, 0)), // entry portal of next sector
+			(SectorID::new(1, 1), FieldCell::new(5, 9)), // exit portal of next sector
+			(SectorID::new(1, 2), FieldCell::new(5, 0)), // entry portal of next sector
+			(SectorID::new(1, 2), FieldCell::new(0, 3)), // exit portal of next sector
+			(SectorID::new(0, 2), FieldCell::new(9, 3)) // goal sector and entry portal
 		];
-		let target_goal = (4, 4);
+		let target_goal = FieldCell::new(4, 4);
 
 		filter_path(&mut path, target_goal);
 		let actual = vec![
-			((2, 0), (0, 4)),
-			((1, 0), (3, 9)),
-			((1, 1), (5, 9)),
-			((1, 2), (0, 3)),
-			((0, 2), (4, 4)) // gets switch to target_goal
+			(SectorID::new(2, 0), FieldCell::new(0, 4)),
+			(SectorID::new(1, 0), FieldCell::new(3, 9)),
+			(SectorID::new(1, 1), FieldCell::new(5, 9)),
+			(SectorID::new(1, 2), FieldCell::new(0, 3)),
+			(SectorID::new(0, 2), FieldCell::new(4, 4)) // gets switch to target_goal
 		];
 
 		assert_eq!(actual, path);
@@ -265,25 +265,25 @@ mod tests {
 		// path in 3x3 sector grid, moving from top right to top right
 		// i.e impassable values mean that the actor must leave its starting sector and
 		// re-enter it from a different portal
-		let mut path: Vec<((u32, u32), (usize, usize))> = vec![
-			((2, 0), (8, 9)), // start sector and exit
-			((2, 1), (8, 0)), // entry portal of next sector
-			((2, 1), (6, 0)), // exit back towards start sector
-			((2, 0), (6, 9)), // entry back into start sector
-			((2, 0), (4, 9)), // leave starting sector again
-			((2, 1), (4, 0)), // entry of neighbour again
-			((2, 1), (2, 0)), // exit back towrards start again
-			((2, 0), (2, 9)), // last entry into original sector
+		let mut path: Vec<(SectorID, FieldCell)> = vec![
+			(SectorID::new(2, 0), FieldCell::new(8, 9)), // start sector and exit
+			(SectorID::new(2, 1), FieldCell::new(8, 0)), // entry portal of next sector
+			(SectorID::new(2, 1), FieldCell::new(6, 0)), // exit back towards start sector
+			(SectorID::new(2, 0), FieldCell::new(6, 9)), // entry back into start sector
+			(SectorID::new(2, 0), FieldCell::new(4, 9)), // leave starting sector again
+			(SectorID::new(2, 1), FieldCell::new(4, 0)), // entry of neighbour again
+			(SectorID::new(2, 1), FieldCell::new(2, 0)), // exit back towrards start again
+			(SectorID::new(2, 0), FieldCell::new(2, 9)), // last entry into original sector
 		];
-		let target_goal = (2, 1);
+		let target_goal = FieldCell::new(2, 1);
 
 		filter_path(&mut path, target_goal);
 		let actual = vec![
-			((2, 0), (8, 9)),
-			((2, 1), (6, 0)),
-			((2, 0), (4, 9)),
-			((2, 1), (2, 0)),
-			((2, 0), (2, 1)), // gets switch to target_goal
+			(SectorID::new(2, 0), FieldCell::new(8, 9)),
+			(SectorID::new(2, 1), FieldCell::new(6, 0)),
+			(SectorID::new(2, 0), FieldCell::new(4, 9)),
+			(SectorID::new(2, 1), FieldCell::new(2, 0)),
+			(SectorID::new(2, 0), FieldCell::new(2, 1)), // gets switch to target_goal
 		];
 
 		assert_eq!(actual, path);

--- a/src/plugin/flow_layer.rs
+++ b/src/plugin/flow_layer.rs
@@ -10,11 +10,11 @@ use bevy::prelude::*;
 pub struct EventPathRequest {
 	/// The starting sector of the request
 	source_sector: SectorID,
-	/// The starting field/grid cell of the starting sector
+	/// The starting field cell of the starting sector
 	source_field_cell: FieldCell,
 	/// The sector to try and find a path to
 	target_sector: SectorID,
-	/// The field/grid cell in the target sector to find a path to
+	/// The field cell in the target sector to find a path to
 	target_goal: FieldCell,
 }
 
@@ -95,7 +95,6 @@ pub fn handle_path_requests(
 /// for an actors entry and when for an actors exit, we only need to know
 /// about the elements which an actor would use to exit the sector so we filter
 /// the route and trim it down
-#[allow(clippy::type_complexity)]
 pub fn filter_path(path: &mut Vec<(SectorID, FieldCell)>, target_goal: FieldCell) {
 	let mut path_based_on_portal_exits = Vec::new();
 	// target sector and entry portal where we switch the entry portal cell to the goal
@@ -145,7 +144,7 @@ pub fn generate_flow_fields(
 					sectors_expanded_goals.push((*sector_id, vec![*goal]));
 				} else {
 					// portals represent the boundary to another sector, a portal can be spread over
-					// multple grid cells, expand the portal to provide multiple goal
+					// multple field cells, expand the portal to provide multiple goal
 					// targets for moving to another sector
 					let neighbour_sector_id = path[i - 1].0;
 					let g = sector_portals

--- a/tests/construct_each_field.rs
+++ b/tests/construct_each_field.rs
@@ -29,10 +29,10 @@ fn field_on_field() {
 		map_dimensions.get_row(),
 	);
 	//
-	let source_sector = (2, 0);
-	let source_grid_cell = (7, 3);
-	let target_sector = (0, 2);
-	let target_grid_cell = (0, 6);
+	let source_sector = SectorID::new(2, 0);
+	let source_grid_cell = FieldCell::new(7, 3);
+	let target_sector = SectorID::new(0, 2);
+	let target_grid_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(

--- a/tests/construct_each_field.rs
+++ b/tests/construct_each_field.rs
@@ -30,25 +30,25 @@ fn field_on_field() {
 	);
 	//
 	let source_sector = SectorID::new(2, 0);
-	let source_grid_cell = FieldCell::new(7, 3);
+	let source_field_cell = FieldCell::new(7, 3);
 	let target_sector = SectorID::new(0, 2);
-	let target_grid_cell = FieldCell::new(0, 6);
+	let target_field_cell = FieldCell::new(0, 6);
 	// path from actor to goal sectors
 	let node_path = portal_graph
 		.find_best_path(
-			(source_sector, source_grid_cell),
-			(target_sector, target_grid_cell),
+			(source_sector, source_field_cell),
+			(target_sector, target_field_cell),
 			&sector_portals,
 			&sector_cost_fields,
 		)
 		.unwrap();
-	// convert to grid and sector coords
+	// convert to field cell and sector coords
 	let mut path =
 		portal_graph.convert_index_path_to_sector_portal_cells(node_path.1, &sector_portals);
 	// original order is from actor to goal, int fields need to be processed the other way around
 	path.reverse();
 	// change target cell from portal to the real goal
-	path[0].1 = target_grid_cell;
+	path[0].1 = target_field_cell;
 	let mut sector_order = Vec::new();
 	let mut map = HashMap::new();
 	for p in path.iter() {


### PR DESCRIPTION
* Sector ID `(u32, 32)` is now stored a struct `SectorID`
* Grid cell IDs `(usize, usize)` are now stored as struct `FieldCell`
* Switched language away from 'grid cell' preferring to use 'field cell'