### PR TITLE
test: replaced collision detection in 2d examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ publish = true
 criterion = "0.5"
 bevy = { workspace = true, default-features = true }
 rand = "0.8"
+bevy_xpbd_2d = { version = "0.3", default-features = false, features = ["2d", "f32", "parallel", "debug-plugin"]} # used in 2d exmaples for collision detection
 # examples_utils = { path = "crates/examples_utils" }
 
 [dependencies]

--- a/examples/2d_complex_movement.rs
+++ b/examples/2d_complex_movement.rs
@@ -1,26 +1,23 @@
 //! Generates a 30x30 world where an actor can be told to move through a narrow snake-like path
 //!
 //TODO visualisation creates impassable blocks when route goes back on self
-use std::time::Duration;
 
-use bevy::{
-	prelude::*,
-	sprite::collide_aabb::{collide, Collision},
-	window::PrimaryWindow,
-};
+use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_flowfield_tiles_plugin::prelude::*;
+use bevy_xpbd_2d::prelude::*;
 
-/// Timestep of actor movement system
-const ACTOR_TIMESTEP: f32 = 1.0 / 60.0;
 /// Dimension of square sprites making up the world
 const FIELD_SPRITE_DIMENSION: f32 = 64.0;
 
 fn main() {
 	App::new()
-		.add_plugins(DefaultPlugins)
-		.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs_f32(
-			ACTOR_TIMESTEP,
-		)))
+		.add_plugins((
+			DefaultPlugins,
+			PhysicsPlugins::default(),
+			// PhysicsDebugPlugin::default(),
+		))
+		.insert_resource(SubstepCount(30))
+		.insert_resource(Gravity(Vec2::ZERO))
 		.add_plugins(FlowFieldTilesPlugin)
 		.add_systems(
 			Startup,
@@ -29,10 +26,7 @@ fn main() {
 		.add_systems(Update, (user_input, actor_update_route))
 		//TODO this system is updating sprite textures wrong, black boxes over tiles
 		// .add_systems(Update, (update_sprite_visuals_based_on_actor,))
-		.add_systems(
-			FixedUpdate,
-			(actor_steering, collision_detection, apply_velocity).chain(),
-		)
+		.add_systems(Update, actor_steering)
 		.run();
 }
 
@@ -59,15 +53,8 @@ struct Pathing {
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
-	current_direction: Option<Vec2>,
-	/// Helps to steer the actor around corners when it is very close to an impassable field cell and reduces the likihood on tunneling
-	previous_direction: Option<Vec2>,
 	has_los: bool,
 }
-
-/// Dir and magnitude of actor movement
-#[derive(Component, Default)]
-struct Velocity(Vec2);
 
 /// Spawn sprites to represent the world
 fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
@@ -94,24 +81,22 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 				// add colliders to impassable cells
 				if *value == 255 {
 					cmds.spawn(SpriteBundle {
-						texture: asset_server.load(get_basic_icon(*value)),
-						transform: Transform::from_xyz(x, y, 0.0),
+						sprite: Sprite {
+							color: Color::BLACK,
+							..default()
+						},
+						transform: Transform {
+							translation: Vec3::new(x, y, 0.0),
+							scale: Vec3::new(FIELD_SPRITE_DIMENSION, FIELD_SPRITE_DIMENSION, 1.0),
+							..default()
+						},
 						..default()
 					})
 					.insert(FieldCellLabel(i, j))
 					.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()))
-					.with_children(|p| {
-						// required to have a collider sized correctly
-						p.spawn(SpatialBundle {
-							transform: Transform::from_scale(Vec3::new(
-								FIELD_SPRITE_DIMENSION,
-								FIELD_SPRITE_DIMENSION,
-								1.0,
-							)),
-							..default()
-						})
-						.insert(Collider);
-					});
+					.insert(Collider::cuboid(1.0, 1.0))
+					.insert(RigidBody::Static)
+					.insert(CollisionLayers::new([Layer::Terrain], [Layer::Actor]));
 				} else {
 					cmds.spawn(SpriteBundle {
 						texture: asset_server.load(get_basic_icon(*value)),
@@ -126,7 +111,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	}
 }
 /// Spawn navigation related entities
-fn setup_navigation(mut cmds: Commands, asset_server: Res<AssetServer>) {
+fn setup_navigation(mut cmds: Commands) {
 	// create the entity handling the algorithm
 	let dir = env!("CARGO_MANIFEST_DIR").to_string() + "/assets/csv/vis_portals/";
 	let map_length = 1920;
@@ -142,19 +127,27 @@ fn setup_navigation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	));
 	// create the controllable actor in the top right corner
 	cmds.spawn(SpriteBundle {
-		texture: asset_server.load("2d/2d_actor_sprite.png"),
-		transform: Transform::from_xyz(-928.0, -928.0, 1.0),
+		sprite: Sprite {
+			color: Color::Rgba {
+				red: 230.0,
+				green: 0.0,
+				blue: 255.0,
+				alpha: 1.0,
+			},
+			..default()
+		},
+		transform: Transform {
+			translation: Vec3::new(-928.0, -900.0, 1.0),
+			scale: Vec3::new(16.0, 16.0, 1.0),
+			..default()
+		},
 		..default()
 	})
 	.insert(Actor)
-	.insert(Velocity::default())
 	.insert(Pathing::default())
-	.with_children(|p| {
-		p.spawn(SpatialBundle {
-			transform: Transform::from_scale(Vec3::new(16.0, 16.0, 1.0)),
-			..default()
-		});
-	});
+	.insert(RigidBody::Dynamic)
+	.insert(Collider::cuboid(1.0, 1.0))
+	.insert(CollisionLayers::new([Layer::Actor], [Layer::Terrain]));
 }
 
 /// Handle generating a PathRequest via right click
@@ -217,70 +210,59 @@ fn actor_update_route(mut actor_q: Query<&mut Pathing, With<Actor>>, route_q: Qu
 		}
 	}
 }
-/// Actor speed measured in pixels per fixed tick
-const SPEED: f32 = 250.0;
+/// Actor speed
+const SPEED: f32 = 50000.0;
 
 /// If the actor has a destination set then try to retrieve the relevant
 /// [FlowField] for its current position and move the actor
 fn actor_steering(
-	mut actor_q: Query<(&mut Velocity, &mut Transform, &mut Pathing), With<Actor>>,
+	mut actor_q: Query<(&mut LinearVelocity, &mut Transform, &mut Pathing), With<Actor>>,
 	flow_cache_q: Query<(&FlowFieldCache, &MapDimensions)>,
 	time_step: Res<Time>,
 ) {
-	let (mut velocity, tform, mut pathing) = actor_q.get_single_mut().unwrap();
 	let (flow_cache, map_dimensions) = flow_cache_q.get_single().unwrap();
 
-	if pathing.target_goal.is_some() {
-		// lookup the overarching route
-		if let Some(route) = pathing.portal_route.as_mut() {
-			// info!("Route: {:?}", route);
-			// find the current actors postion in grid space
-			let (curr_actor_sector, curr_actor_field_cell) = map_dimensions
-				.get_sector_and_field_id_from_xy(tform.translation.truncate())
-				.unwrap();
-			// tirm the actor stored route as it makes progress
-			// this ensures it doesn't use a previous goal from
-			// a sector it has already been through when it needs
-			// to pass through it again as part of a different part of the route
-			if curr_actor_sector != route.first().unwrap().0 {
-				route.remove(0);
-			}
-			// lookup the relevant sector-goal of this sector
-			'routes: for (sector, goal) in route.iter() {
-				if *sector == curr_actor_sector {
-					// get the flow field
-					if let Some(field) = flow_cache.get_field(*sector, *goal) {
-						// based on actor field cell find the directional vector it should move in
-						let cell_value = field.get_field_cell_value(curr_actor_field_cell);
-						if has_line_of_sight(cell_value) {
-							pathing.has_los = true;
-							let dir =
-								pathing.target_position.unwrap() - tform.translation.truncate();
-							velocity.0 = dir.normalize() * SPEED * time_step.delta_seconds();
-							break 'routes;
+	for (mut velocity, tform, mut pathing) in &mut actor_q {
+		if pathing.target_goal.is_some() {
+			// lookup the overarching route
+			if let Some(route) = pathing.portal_route.as_mut() {
+				// info!("Route: {:?}", route);
+				// find the current actors postion in grid space
+				let (curr_actor_sector, curr_actor_field_cell) = map_dimensions
+					.get_sector_and_field_id_from_xy(tform.translation.truncate())
+					.unwrap();
+				// tirm the actor stored route as it makes progress
+				// this ensures it doesn't use a previous goal from
+				// a sector it has already been through when it needs
+				// to pass through it again as part of a different part of the route
+				if curr_actor_sector != route.first().unwrap().0 {
+					route.remove(0);
+				}
+				// lookup the relevant sector-goal of this sector
+				'routes: for (sector, goal) in route.iter() {
+					if *sector == curr_actor_sector {
+						// get the flow field
+						if let Some(field) = flow_cache.get_field(*sector, *goal) {
+							// based on actor field cell find the directional vector it should move in
+							let cell_value = field.get_field_cell_value(curr_actor_field_cell);
+							if has_line_of_sight(cell_value) {
+								pathing.has_los = true;
+								let dir =
+									pathing.target_position.unwrap() - tform.translation.truncate();
+								velocity.0 = dir.normalize() * SPEED * time_step.delta_seconds();
+								break 'routes;
+							}
+							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
+							velocity.0 = dir * SPEED * time_step.delta_seconds();
 						}
-						let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-						if pathing.current_direction.is_none() {
-							pathing.current_direction = Some(dir);
-						} else if pathing.current_direction.unwrap() != dir {
-							pathing.previous_direction = pathing.current_direction;
-							pathing.current_direction = Some(dir);
-						}
-						velocity.0 = dir * SPEED * time_step.delta_seconds();
+						break 'routes;
 					}
-					break 'routes;
 				}
 			}
 		}
 	}
 }
 
-/// Move the actor
-fn apply_velocity(mut actor_q: Query<(&Velocity, &mut Transform), With<Actor>>) {
-	for (velocity, mut tform) in actor_q.iter_mut() {
-		tform.translation += velocity.0.extend(0.0);
-	}
-}
 /// Get asset path to sprite icons
 fn get_basic_icon(value: u8) -> String {
 	if value == 255 {
@@ -361,9 +343,26 @@ fn get_basic_icon(value: u8) -> String {
 // 	}
 // }
 
-/// Added to entities that should block actors
-#[derive(Component)]
-struct Collider;
+/// Used in CollisionLayers so that actors don't collide with one another, only the terrain
+#[allow(clippy::missing_docs_in_private_items)]
+enum Layer {
+	Actor,
+	Terrain,
+}
+
+// weird bug when using #derive where it thinks the crate bevy_xpbd_3d is being used >(
+impl PhysicsLayer for Layer {
+	fn to_bits(&self) -> u32 {
+		match self {
+			Layer::Actor => 1,
+			Layer::Terrain => 2,
+		}
+	}
+
+	fn all_bits() -> u32 {
+		0b11
+	}
+}
 
 /// Create collider entities around the world
 fn create_wall_colliders(mut cmds: Commands) {
@@ -413,63 +412,9 @@ fn create_wall_colliders(mut cmds: Commands) {
 				},
 				..default()
 			},
-			Collider,
+			RigidBody::Static,
+			Collider::cuboid(1.0, 1.0),
+			CollisionLayers::new([Layer::Terrain], []),
 		));
-	}
-}
-
-/// Rebound actors when they begin to overlap an impassable area
-fn collision_detection(
-	mut actor_q: Query<(&mut Velocity, &Transform, &Children, &Pathing), With<Actor>>,
-	actor_child_q: Query<&Transform>,
-	static_colliders: Query<(&Parent, &Transform), With<Collider>>,
-	parent_colliders: Query<&Transform>,
-	time_step: Res<Time>,
-) {
-	for (mut velocity, actor_tform, children, pathing) in actor_q.iter_mut() {
-		for (parent, child_collider_tform) in static_colliders.iter() {
-			let parent_collider_tform = parent_colliders.get(parent.get()).unwrap();
-			for &child in children {
-				let tform = actor_child_q.get(child).unwrap();
-				let collision = collide(
-					actor_tform.translation,
-					tform.scale.truncate(),
-					parent_collider_tform.translation,
-					child_collider_tform.scale.truncate(),
-				);
-				if let Some(collision) = collision {
-					// direct the actor away from the collider
-					match collision {
-						Collision::Left => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Right => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Top => {
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Bottom => {
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Inside => {
-							velocity.0 *= -1.0;
-						}
-					}
-				}
-			}
-		}
 	}
 }

--- a/examples/2d_continuous.rs
+++ b/examples/2d_continuous.rs
@@ -1,27 +1,28 @@
 //! Generates a 30x30 world and endlessly spawns actors with randomised destinations
 //!
 
-use std::time::Duration;
-
 use bevy::{
 	diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
 	prelude::*,
-	sprite::collide_aabb::{collide, Collision},
 };
+
 use bevy_flowfield_tiles_plugin::prelude::*;
+use bevy_xpbd_2d::prelude::*;
 use rand::seq::SliceRandom;
 
-/// Timestep of actor movement system
-const ACTOR_TIMESTEP: f32 = 1.0 / 60.0;
 /// Dimension of square sprites making up the world
 const FIELD_SPRITE_DIMENSION: f32 = 64.0;
 
 fn main() {
 	App::new()
-		.add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin))
-		.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs_f32(
-			ACTOR_TIMESTEP,
-		)))
+		.add_plugins((
+			DefaultPlugins,
+			FrameTimeDiagnosticsPlugin,
+			PhysicsPlugins::default(),
+			// PhysicsDebugPlugin::default(),
+		))
+		.insert_resource(SubstepCount(30))
+		.insert_resource(Gravity(Vec2::ZERO))
 		.add_plugins(FlowFieldTilesPlugin)
 		.add_systems(
 			Startup,
@@ -43,10 +44,7 @@ fn main() {
 				update_elapsed_counter,
 			),
 		)
-		.add_systems(
-			FixedUpdate,
-			(actor_steering, collision_detection, apply_velocity).chain(),
-		)
+		.add_systems(Update, actor_steering)
 		.run();
 }
 
@@ -74,14 +72,28 @@ struct Pathing {
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
-	current_direction: Option<Vec2>,
-	/// Helps to steer the actor around corners when it is very close to an impassable field cell and reduces the likihood on tunneling
-	previous_direction: Option<Vec2>,
 	has_los: bool,
 }
-/// Dir and magnitude of actor movement
-#[derive(Component, Default)]
-struct Velocity(Vec2);
+
+/// Used in CollisionLayers so that actors don't collide with one another, only the terrain
+#[allow(clippy::missing_docs_in_private_items)]
+enum Layer {
+	Actor,
+	Terrain,
+}
+// weird bug when using #derive where it thinks the crate bevy_xpbd_3d is being used >(
+impl PhysicsLayer for Layer {
+	fn to_bits(&self) -> u32 {
+		match self {
+			Layer::Actor => 1,
+			Layer::Terrain => 2,
+		}
+	}
+
+	fn all_bits() -> u32 {
+		0b11
+	}
+}
 
 /// Spawn sprites to represent the world
 fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
@@ -109,24 +121,22 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 				// add colliders to impassable cells
 				if *value == 255 {
 					cmds.spawn(SpriteBundle {
-						texture: asset_server.load(get_basic_icon(*value)),
-						transform: Transform::from_xyz(x, y, 0.0),
+						sprite: Sprite {
+							color: Color::BLACK,
+							..default()
+						},
+						transform: Transform {
+							translation: Vec3::new(x, y, 0.0),
+							scale: Vec3::new(FIELD_SPRITE_DIMENSION, FIELD_SPRITE_DIMENSION, 1.0),
+							..default()
+						},
 						..default()
 					})
 					.insert(FieldCellLabel(i, j))
 					.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()))
-					.with_children(|p| {
-						// required to have a collider sized correctly
-						p.spawn(SpatialBundle {
-							transform: Transform::from_scale(Vec3::new(
-								FIELD_SPRITE_DIMENSION,
-								FIELD_SPRITE_DIMENSION,
-								1.0,
-							)),
-							..default()
-						})
-						.insert(Collider);
-					});
+					.insert(Collider::cuboid(1.0, 1.0))
+					.insert(RigidBody::Static)
+					.insert(CollisionLayers::new([Layer::Terrain], [Layer::Actor]));
 				} else {
 					cmds.spawn(SpriteBundle {
 						texture: asset_server.load(get_basic_icon(*value)),
@@ -163,7 +173,6 @@ fn setup_navigation(mut cmds: Commands) {
 /// map and a random destination at the bottom
 fn spawn_actors(
 	mut cmds: Commands,
-	asset_server: Res<AssetServer>,
 	map: Query<&MapDimensions>,
 	mut event: EventWriter<EventPathRequest>,
 ) {
@@ -222,27 +231,33 @@ fn spawn_actors(
 			target_sector: Some(t_sector),
 			target_goal: Some(t_field),
 			portal_route: None,
-			current_direction: None,
-			previous_direction: None,
 			has_los: false,
 		};
 		// request a path
 		event.send(EventPathRequest::new(sector_id, field, t_sector, t_field));
 		// spawn the actor which cna read the path later
 		cmds.spawn(SpriteBundle {
-			texture: asset_server.load("2d/2d_actor_sprite.png"),
-			transform: Transform::from_xyz(start_x, start_y, 1.0),
+			sprite: Sprite {
+				color: Color::Rgba {
+					red: 230.0,
+					green: 0.0,
+					blue: 255.0,
+					alpha: 1.0,
+				},
+				..default()
+			},
+			transform: Transform {
+				translation: Vec3::new(start_x, start_y, 1.0),
+				scale: Vec3::new(16.0, 16.0, 1.0),
+				..default()
+			},
 			..default()
 		})
 		.insert(Actor)
-		.insert(Velocity::default())
-		.insert(pathing)
-		.with_children(|p| {
-			p.spawn(SpatialBundle {
-				transform: Transform::from_scale(Vec3::new(16.0, 16.0, 1.0)),
-				..default()
-			});
-		});
+		.insert(RigidBody::Dynamic)
+		.insert(Collider::cuboid(1.0, 1.0))
+		.insert(CollisionLayers::new([Layer::Actor], [Layer::Terrain]))
+		.insert(pathing);
 	}
 }
 
@@ -262,13 +277,13 @@ fn actor_update_route(mut actor_q: Query<&mut Pathing, With<Actor>>, route_q: Qu
 		}
 	}
 }
-/// Actor speed measured in pixels per fixed tick
-const SPEED: f32 = 250.0;
+/// Actor speed
+const SPEED: f32 = 40000.0;
 
 /// If the actor has a destination set then try to retrieve the relevant
 /// [FlowField] for its current position and move the actor
 fn actor_steering(
-	mut actor_q: Query<(&mut Velocity, &mut Transform, &mut Pathing), With<Actor>>,
+	mut actor_q: Query<(&mut LinearVelocity, &mut Transform, &mut Pathing), With<Actor>>,
 	flow_cache_q: Query<(&FlowFieldCache, &MapDimensions)>,
 	time_step: Res<Time>,
 ) {
@@ -302,16 +317,9 @@ fn actor_steering(
 								let dir =
 									pathing.target_position.unwrap() - tform.translation.truncate();
 								velocity.0 = dir.normalize() * SPEED * time_step.delta_seconds();
-								// pathing.previous_direction = Some(-dir.normalize());
 								break 'routes;
 							}
 							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-							if pathing.current_direction.is_none() {
-								pathing.current_direction = Some(dir);
-							} else if pathing.current_direction.unwrap() != dir {
-								pathing.previous_direction = pathing.current_direction;
-								pathing.current_direction = Some(dir);
-							}
 							velocity.0 = dir * SPEED * time_step.delta_seconds();
 						}
 						break 'routes;
@@ -319,13 +327,6 @@ fn actor_steering(
 				}
 			}
 		}
-	}
-}
-
-/// Move the actor
-fn apply_velocity(mut actor_q: Query<(&Velocity, &mut Transform), With<Actor>>) {
-	for (velocity, mut tform) in actor_q.iter_mut() {
-		tform.translation += velocity.0.extend(0.0);
 	}
 }
 
@@ -362,10 +363,6 @@ fn get_basic_icon(value: u8) -> String {
 		panic!("Require basic icon")
 	}
 }
-
-/// Added to entities that should block actors
-#[derive(Component)]
-struct Collider;
 
 /// Create collider entities around the world
 fn create_wall_colliders(mut cmds: Commands) {
@@ -415,67 +412,10 @@ fn create_wall_colliders(mut cmds: Commands) {
 				},
 				..default()
 			},
-			Collider,
+			RigidBody::Static,
+			Collider::cuboid(1.0, 1.0),
+			CollisionLayers::new([Layer::Terrain], []),
 		));
-	}
-}
-
-/// Rebound actors when they begin to overlap an impassable area
-fn collision_detection(
-	mut actor_q: Query<(&mut Velocity, &Transform, &Children, &Pathing), With<Actor>>,
-	actor_child_q: Query<&Transform>,
-	static_colliders: Query<(&Parent, &Transform), With<Collider>>,
-	parent_colliders: Query<&Transform>,
-	time_step: Res<Time>,
-) {
-	for (mut velocity, actor_tform, children, pathing) in actor_q.iter_mut() {
-		for (parent, child_collider_tform) in static_colliders.iter() {
-			let parent_collider_tform = parent_colliders.get(parent.get()).unwrap();
-			for &child in children {
-				let tform = actor_child_q.get(child).unwrap();
-				let collision = collide(
-					actor_tform.translation,
-					tform.scale.truncate(),
-					parent_collider_tform.translation,
-					child_collider_tform.scale.truncate(),
-				);
-				if let Some(collision) = collision {
-					// direct the actor away from the collider
-					match collision {
-						Collision::Left => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Right => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Top => {
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Bottom => {
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Inside => {
-							// velocity.0 *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0 = dir * SPEED * time_step.delta_seconds() * 3.0;
-							}
-						}
-					}
-				}
-			}
-		}
 	}
 }
 

--- a/examples/2d_with_steering.rs
+++ b/examples/2d_with_steering.rs
@@ -1,26 +1,24 @@
 //! Generates a 30x30 world where an actor can be told to navigate to a point with a right click
 //!
 
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
-use bevy::{
-	prelude::*,
-	sprite::collide_aabb::{collide, Collision},
-	window::PrimaryWindow,
-};
+use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_flowfield_tiles_plugin::prelude::*;
+use bevy_xpbd_2d::prelude::*;
 
-/// Timestep of actor movement system
-const ACTOR_TIMESTEP: f32 = 1.0 / 60.0;
 /// Dimension of square sprites making up the world
 const FIELD_SPRITE_DIMENSION: f32 = 64.0;
 
 fn main() {
 	App::new()
-		.add_plugins(DefaultPlugins)
-		.insert_resource(Time::<Fixed>::from_duration(Duration::from_secs_f32(
-			ACTOR_TIMESTEP,
-		)))
+		.add_plugins((
+			DefaultPlugins,
+			PhysicsPlugins::default(),
+			// PhysicsDebugPlugin::default(),
+		))
+		.insert_resource(SubstepCount(30))
+		.insert_resource(Gravity(Vec2::ZERO))
 		.add_plugins(FlowFieldTilesPlugin)
 		.add_systems(
 			Startup,
@@ -28,10 +26,7 @@ fn main() {
 		)
 		.add_systems(Update, (user_input, actor_update_route))
 		.add_systems(Update, (update_sprite_visuals_based_on_actor,))
-		.add_systems(
-			FixedUpdate,
-			(actor_steering, collision_detection, apply_velocity).chain(),
-		)
+		.add_systems(Update, actor_steering)
 		.run();
 }
 
@@ -58,15 +53,8 @@ struct Pathing {
 	target_sector: Option<SectorID>,
 	target_goal: Option<FieldCell>,
 	portal_route: Option<Vec<(SectorID, FieldCell)>>,
-	current_direction: Option<Vec2>,
-	/// Helps to steer the actor around corners when it is very close to an impassable field cell and reduces the likihood on tunneling
-	previous_direction: Option<Vec2>,
 	has_los: bool,
 }
-
-/// Dir and magnitude of actor movement
-#[derive(Component, Default)]
-struct Velocity(Vec2);
 
 /// Spawn sprites to represent the world
 fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
@@ -105,18 +93,12 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 					})
 					.insert(FieldCellLabel(i, j))
 					.insert(SectorLabel(sector_id.get_column(), sector_id.get_row()))
-					.with_children(|p| {
-						// required to have a collider sized correctly
-						p.spawn(SpatialBundle {
-							transform: Transform::from_scale(Vec3::new(
-								FIELD_SPRITE_DIMENSION,
-								FIELD_SPRITE_DIMENSION,
-								1.0,
-							)),
-							..default()
-						})
-						.insert(Collider);
-					});
+					.insert(Collider::cuboid(
+						FIELD_SPRITE_DIMENSION,
+						FIELD_SPRITE_DIMENSION,
+					))
+					.insert(RigidBody::Static)
+					.insert(CollisionLayers::new([Layer::Terrain], [Layer::Actor]));
 				} else {
 					cmds.spawn(SpriteBundle {
 						texture: asset_server.load(get_basic_icon(*value)),
@@ -131,7 +113,7 @@ fn setup_visualisation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	}
 }
 /// Spawn navigation related entities
-fn setup_navigation(mut cmds: Commands, asset_server: Res<AssetServer>) {
+fn setup_navigation(mut cmds: Commands) {
 	// create the entity handling the algorithm
 	let path = env!("CARGO_MANIFEST_DIR").to_string() + "/assets/sector_cost_fields.ron";
 	let map_length = 1920;
@@ -147,19 +129,27 @@ fn setup_navigation(mut cmds: Commands, asset_server: Res<AssetServer>) {
 	));
 	// create the controllable actor in the top right corner
 	cmds.spawn(SpriteBundle {
-		texture: asset_server.load("2d/2d_actor_sprite.png"),
-		transform: Transform::from_xyz(928.0, 928.0, 1.0),
+		sprite: Sprite {
+			color: Color::Rgba {
+				red: 230.0,
+				green: 0.0,
+				blue: 255.0,
+				alpha: 1.0,
+			},
+			..default()
+		},
+		transform: Transform {
+			translation: Vec3::new(928.0, 920.0, 1.0),
+			scale: Vec3::new(16.0, 16.0, 1.0),
+			..default()
+		},
 		..default()
 	})
 	.insert(Actor)
-	.insert(Velocity::default())
 	.insert(Pathing::default())
-	.with_children(|p| {
-		p.spawn(SpatialBundle {
-			transform: Transform::from_scale(Vec3::new(16.0, 16.0, 1.0)),
-			..default()
-		});
-	});
+	.insert(RigidBody::Dynamic)
+	.insert(Collider::cuboid(1.0, 1.0))
+	.insert(CollisionLayers::new([Layer::Actor], [Layer::Terrain]));
 }
 
 /// Handle generating a PathRequest via right click
@@ -222,67 +212,57 @@ fn actor_update_route(mut actor_q: Query<&mut Pathing, With<Actor>>, route_q: Qu
 		}
 	}
 }
-/// Actor speed measured in pixels per fixed tick
-const SPEED: f32 = 250.0;
+/// Actor speed
+const SPEED: f32 = 50000.0;
 
 /// If the actor has a destination set then try to retrieve the relevant
 /// [FlowField] for its current position and move the actor
 fn actor_steering(
-	mut actor_q: Query<(&mut Velocity, &mut Transform, &mut Pathing), With<Actor>>,
+	mut actor_q: Query<(&mut LinearVelocity, &mut Transform, &mut Pathing), With<Actor>>,
 	flow_cache_q: Query<(&FlowFieldCache, &MapDimensions)>,
 	time_step: Res<Time>,
 ) {
-	let (mut velocity, tform, mut pathing) = actor_q.get_single_mut().unwrap();
 	let (flow_cache, map_dimensions) = flow_cache_q.get_single().unwrap();
 
-	if pathing.target_goal.is_some() {
-		// lookup the overarching route
-		if let Some(route) = pathing.portal_route.as_mut() {
-			// info!("Route: {:?}", route);
-			// find the current actors postion in grid space
-			let (curr_actor_sector, curr_actor_field_cell) = map_dimensions
-				.get_sector_and_field_id_from_xy(tform.translation.truncate())
-				.unwrap();
-			// tirm the actor stored route as it makes progress
-			// this ensures it doesn't use a previous goal from
-			// a sector it has already been through when it needs
-			// to pass through it again as part of a different part of the route
-			if curr_actor_sector != route.first().unwrap().0 {
-				route.remove(0);
-			}
-			// lookup the relevant sector-goal of this sector
-			'routes: for (sector, goal) in route.iter() {
-				if *sector == curr_actor_sector {
-					// get the flow field
-					if let Some(field) = flow_cache.get_field(*sector, *goal) {
-						// based on actor field cell find the directional vector it should move in
-						let cell_value = field.get_field_cell_value(curr_actor_field_cell);
-						if has_line_of_sight(cell_value) {
-							pathing.has_los = true;
-							let dir =
-								pathing.target_position.unwrap() - tform.translation.truncate();
-							velocity.0 = dir.normalize() * SPEED * time_step.delta_seconds();
-							break 'routes;
-						}
-						let dir = get_2d_direction_unit_vector_from_bits(cell_value);
-						if pathing.current_direction.is_none() {
-							pathing.current_direction = Some(dir);
-						} else if pathing.current_direction.unwrap() != dir {
-							pathing.previous_direction = pathing.current_direction;
-							pathing.current_direction = Some(dir);
-						}
-						velocity.0 = dir * SPEED * time_step.delta_seconds();
+	for (mut velocity, tform, mut pathing) in actor_q.iter_mut() {
+		if pathing.target_goal.is_some() {
+			// lookup the overarching route
+			if let Some(route) = pathing.portal_route.as_mut() {
+				// find the current actors postion in grid space
+				let (curr_actor_sector, curr_actor_field_cell) = map_dimensions
+					.get_sector_and_field_id_from_xy(tform.translation.truncate())
+					.unwrap();
+				// tirm the actor stored route as it makes progress
+				// this ensures it doesn't use a previous goal from
+				// a sector it has already been through when it needs
+				// to pass through it again as part of a different part of the route
+				if let Some(f) = route.first() {
+					if curr_actor_sector != f.0 {
+						route.remove(0);
 					}
-					break 'routes;
+				}
+				// lookup the relevant sector-goal of this sector
+				'routes: for (sector, goal) in route.iter() {
+					if *sector == curr_actor_sector {
+						// get the flow field
+						if let Some(field) = flow_cache.get_field(*sector, *goal) {
+							// based on actor field cell find the directional vector it should move in
+							let cell_value = field.get_field_cell_value(curr_actor_field_cell);
+							if has_line_of_sight(cell_value) {
+								pathing.has_los = true;
+								let dir =
+									pathing.target_position.unwrap() - tform.translation.truncate();
+								velocity.0 = dir.normalize() * SPEED * time_step.delta_seconds();
+								break 'routes;
+							}
+							let dir = get_2d_direction_unit_vector_from_bits(cell_value);
+							velocity.0 = dir * SPEED * time_step.delta_seconds();
+						}
+						break 'routes;
+					}
 				}
 			}
 		}
-	}
-}
-/// Move the actor
-fn apply_velocity(mut actor_q: Query<(&Velocity, &mut Transform), With<Actor>>) {
-	for (velocity, mut tform) in actor_q.iter_mut() {
-		tform.translation += velocity.0.extend(0.0);
 	}
 }
 
@@ -336,6 +316,9 @@ fn update_sprite_visuals_based_on_actor(
 					.get(&SectorID::new(sector_label.0, sector_label.1))
 					.unwrap()
 					.get_field_cell_value(FieldCell::new(field_cell_label.0, field_cell_label.1));
+				// if value == 255 {
+				// 	continue
+				// }
 				let icon = get_basic_icon(value);
 				let new_handle: Handle<Image> = asset_server.load(icon);
 				*handle = new_handle;
@@ -366,9 +349,26 @@ fn get_ord_icon(value: u8) -> String {
 	}
 }
 
-/// Added to entities that should block actors
-#[derive(Component)]
-struct Collider;
+/// Used in CollisionLayers so that actors don't collide with one another, only the terrain
+#[allow(clippy::missing_docs_in_private_items)]
+enum Layer {
+	Actor,
+	Terrain,
+}
+
+// weird bug when using #derive where it thinks the crate bevy_xpbd_3d is being used >(
+impl PhysicsLayer for Layer {
+	fn to_bits(&self) -> u32 {
+		match self {
+			Layer::Actor => 1,
+			Layer::Terrain => 2,
+		}
+	}
+
+	fn all_bits() -> u32 {
+		0b11
+	}
+}
 
 /// Create collider entities around the world
 fn create_wall_colliders(mut cmds: Commands) {
@@ -418,64 +418,9 @@ fn create_wall_colliders(mut cmds: Commands) {
 				},
 				..default()
 			},
-			Collider,
+			RigidBody::Static,
+			Collider::cuboid(1.0, 1.0),
+			CollisionLayers::new([Layer::Terrain], []),
 		));
-	}
-}
-
-/// Rebound actors when they begin to overlap an impassable area
-fn collision_detection(
-	mut actor_q: Query<(&mut Velocity, &Transform, &Children, &Pathing), With<Actor>>,
-	actor_child_q: Query<&Transform>,
-	static_colliders: Query<(&Parent, &Transform), With<Collider>>,
-	parent_colliders: Query<&Transform>,
-	time_step: Res<Time>,
-) {
-	for (mut velocity, actor_tform, children, pathing) in actor_q.iter_mut() {
-		for (parent, child_collider_tform) in static_colliders.iter() {
-			let parent_collider_tform = parent_colliders.get(parent.get()).unwrap();
-			for &child in children {
-				let tform = actor_child_q.get(child).unwrap();
-				let collision = collide(
-					actor_tform.translation,
-					tform.scale.truncate(),
-					parent_collider_tform.translation,
-					child_collider_tform.scale.truncate(),
-				);
-				if let Some(collision) = collision {
-					// direct the actor away from the collider
-					match collision {
-						Collision::Left => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Right => {
-							velocity.0.x *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.y = dir.y * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Top => {
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Bottom => {
-							info!("{:?}", collision);
-							velocity.0.y *= -1.0;
-							if let Some(dir) = pathing.previous_direction {
-								velocity.0.x = dir.x * SPEED * time_step.delta_seconds() * 2.0;
-							}
-						}
-						Collision::Inside => {
-							velocity.0 *= -1.0;
-						}
-					}
-				}
-			}
-		}
 	}
 }

--- a/src/flowfields/portal/portal_graph.rs
+++ b/src/flowfields/portal/portal_graph.rs
@@ -6,10 +6,10 @@
 //! the agent immediately starts pathing. In the background the other components of the Flowfields can
 //! calcualte a perfect path which can then supersede using portals to path when it's ready
 
-use bevy::utils::{Entry, HashMap};
 use super::portals::Portals;
 use crate::prelude::*;
 use bevy::prelude::*;
+use bevy::utils::{Entry, HashMap};
 
 /// Used to provide a heuristic for portals that sit next to each other across
 /// a portal boundary. This is used in the a-star calculation for determining


### PR DESCRIPTION
Previously the 2d examples used my janky collision detection which allowed some actors to tunnel into colliders and get stuck. That's all been removed and now the `bevy_xpbd_2d` crate has been added as a dev-dependency to showcase the algorithm working alongside a physics simulation. So far xpbd has been really promising and easy to use and now the 2d examples flow nicely   