### PR TITLE
Made scale_all_costfields public to allow for cost field initialization from code without data files

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,17 +10,17 @@ use bevy::prelude::*;
 #[derive(Bundle)]
 pub struct FlowFieldTilesBundle {
 	/// [CostField]s of all sectors
-	sector_cost_fields: SectorCostFields,
+	pub sector_cost_fields: SectorCostFields,
 	/// Portals for all sectors
-	sector_portals: SectorPortals,
+	pub sector_portals: SectorPortals,
 	/// Graph describing how to get from one sector to another
-	portal_graph: PortalGraph,
+	pub portal_graph: PortalGraph,
 	/// Size of the world
-	map_dimensions: MapDimensions,
+	pub map_dimensions: MapDimensions,
 	/// Cache of overarching portal-portal routes
-	route_cache: RouteCache,
+	pub route_cache: RouteCache,
 	/// Cache of [FlowField]s that can be queried in a steering pipeline
-	flow_field_cache: FlowFieldCache,
+	pub flow_field_cache: FlowFieldCache,
 }
 
 impl FlowFieldTilesBundle {

--- a/src/flowfields/sectors/sector_cost.rs
+++ b/src/flowfields/sectors/sector_cost.rs
@@ -98,7 +98,7 @@ impl SectorCostFields {
 	/// Iterate over all sectors and scale any impassable [FieldCell] based on `actor_scale`.
 	///
 	/// This can be expensive so should typically be used as part of data initialisation, i.e when loading [SectorCostFields] from a file or within a loading type of operation to a world
-	fn scale_all_costfields(&mut self, map_dimensions: &MapDimensions) {
+	pub fn scale_all_costfields(&mut self, map_dimensions: &MapDimensions) {
 		let sector_ids: Vec<SectorID> = self.baseline.keys().cloned().collect();
 		for sector_id in sector_ids.iter() {
 			self.scaled.insert(


### PR DESCRIPTION
Very small change, simply making scale_all_costfields public.
The motivation is that I want to create costfields from code without any (static) data files and without calling functions that are meant for for modification of individual fieldcells since that would lead to more scale_costfield calls than necessary.
I would like to set fieldcell costs based on obstacles defined in my code-base and then at the end of this initialization (once all fieldcell costs are set), call scale_all_costfields.

Thanks a lot for this crate btw, really awesome stuff :)
Appreciate the break-down of the design behind it as well.