### PR TITLE
perf: enable wayland support for bevy 

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --release --workspace --all-features
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --release --workspace

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::cargo_common_metadata -D clippy::missing_docs_in_private_items -D clippy::todo -W clippy::unimplemented

--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: |

--- a/.github/workflows/doc-cov.yml
+++ b/.github/workflows/doc-cov.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Nix dependencies
-        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld
+        run: sudo apt-get update; sudo apt-get -y install libasound2-dev libudev-dev lld libwayland-dev
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["crates/examples_utils"]
 
 # Centralised way of managing versions across all crates and packages
 [workspace.dependencies]
-bevy = { version = "0.14", default-features = false, features = ["bevy_render"] }
+bevy = { version = "0.14", default-features = false, features = ["bevy_render", "wayland"] }
 serde = { version = "1", features = ["derive"] }
 ron = { version = "0.8" }
 csv = { version = "1" }
@@ -48,13 +48,13 @@ publish = true
 
 [dev-dependencies]
 criterion = "0.5"
-bevy = { workspace = true, default-features = true }
+bevy = { workspace = true, default-features = true, features=["wayland"]}
 rand = "0.8"
 avian2d = { version = "0.1", default-features = false, features = ["2d", "f32", "parry-f32", "default-collider", "parallel", "debug-plugin"]} # used in 2d exmaples for collision detection
 # examples_utils = { path = "crates/examples_utils" }
 
 [dependencies]
-bevy = { workspace = true, features = ["bevy_render"] }
+bevy = { workspace = true, features = ["bevy_render", "wayland"] }
 serde = { workspace = true, optional = true}
 ron = { workspace = true, optional = true}
 csv = { workspace = true, optional = true}


### PR DESCRIPTION
This is necessary to prevent examples from lagging on wayland sessions. If not enabled bevy is built with x11 support only, and lags like crazy for no fault of the pathing algo, giving bad impression to the user. 

Thanks for the cool implementation! 